### PR TITLE
Add matcher for UNIX timestamps

### DIFF
--- a/lib/masamune/data_plan_elem.rb
+++ b/lib/masamune/data_plan_elem.rb
@@ -16,9 +16,9 @@ class Masamune::DataPlanElem
 
   def path
     if glob
-      start_time.strftime(@rule.pattern.sub('*', glob))
+      start_time.strftime(@rule.strftime_format.sub('*', glob))
     else
-      start_time.strftime(@rule.pattern)
+      start_time.strftime(@rule.strftime_format)
     end
   end
 


### PR DESCRIPTION
Necessary to match event_log files, e.g. `event_logs/$HOST.$PID.$TIMESTAMP.log`
