### PR TITLE
Add no_resolve option

### DIFF
--- a/lib/masamune/actions/data_flow.rb
+++ b/lib/masamune/actions/data_flow.rb
@@ -11,6 +11,7 @@ module Masamune::Actions
         class_option :stop, :aliases => '-b', :desc => 'Stop time', :default => Date.today.to_s
         class_option :sources, :desc => 'File of data sources to process'
         class_option :targets, :desc => 'File of data targets to process'
+        class_option :no_resolve, :type => :boolean, :desc => 'Do not attempt to recursively resolve data dependencies', :default => false
 
         private
 

--- a/lib/masamune/data_plan.rb
+++ b/lib/masamune/data_plan.rb
@@ -101,7 +101,7 @@ class Masamune::DataPlan
         prepare(derived_rule, targets: sources.map(&:path))
         execute(derived_rule, options)
       end
-    end
+    end unless options[:no_resolve]
 
     @command_rules[rule].call(self, rule, options)
     @set_cache.clear

--- a/spec/masamune/data_plan_spec.rb
+++ b/spec/masamune/data_plan_spec.rb
@@ -299,12 +299,14 @@ describe Masamune::DataPlan do
   end
 
   describe '#execute' do
+    let(:options) { {} }
+
     before do
       plan.prepare(rule, targets: targets)
     end
 
     subject(:execute) do
-      plan.execute(rule)
+      plan.execute(rule, options)
     end
 
     context 'primary rule' do
@@ -357,6 +359,18 @@ describe Masamune::DataPlan do
         end
 
         it 'should call touch!' do; end
+      end
+
+      context 'when primary target data exists and :no_resolve is specified' do
+        let(:options) { {no_resolve: true} }
+
+        before do
+          fs.touch!('log/20130101.app1.log', 'log/20130102.app1.log', 'log/20130103.app1.log')
+          fs.should_not_receive(:touch!)
+          execute
+        end
+
+        it 'should not call touch!' do; end
       end
     end
 


### PR DESCRIPTION
Add flag to prevent data dependency resolution- planning to compute visitation data set on a Jenkins box and download data set to 3 OneCloud VMs (e.g. compute once, download 3 times):
https://jira-projects.socialcast.com/browse/SBI-115
