### PR TITLE
Use per context lock

### DIFF
--- a/lib/masamune/data_plan_builder.rb
+++ b/lib/masamune/data_plan_builder.rb
@@ -38,7 +38,7 @@ class Masamune::DataPlanBuilder
 
   def thor_command_wrapper
     Proc.new do |plan, rule, _|
-      Masamune.with_exclusive_lock(rule) do
+      plan.context.with_exclusive_lock(rule) do
         plan.context.parent.invoke(rule)
       end
       plan.filesystem.clear!


### PR DESCRIPTION
At this point [in the execution](https://github.com/socialcast/masamune/blob/master/lib/masamune/data_plan_builder.rb#L41), `:var_dir` is not defined, [so the lock file is global](https://github.com/socialcast/masamune/blob/master/lib/masamune/context.rb#L116).  This is causing issues between ETL environments, for example 'SaaS Prod' is grabbing the global lock `/tmp/event_logs:extract.lock` before 'VF', thus preventing two independent environments from running simultaneously.
