### PR TITLE
Do not pass extra to elastic_mapreduce if passing to delegate command

### DIFF
--- a/lib/masamune/actions/hadoop_streaming.rb
+++ b/lib/masamune/actions/hadoop_streaming.rb
@@ -9,7 +9,7 @@ module Masamune::Actions
         Masamune::Commands::HadoopStreaming.new(context, opts)
       end
 
-      command = Masamune::Commands::ElasticMapReduce.new(command, opts) if configuration.elastic_mapreduce[:jobflow]
+      command = Masamune::Commands::ElasticMapReduce.new(command, opts.except(:extra)) if configuration.elastic_mapreduce[:jobflow]
       command = Masamune::Commands::RetryWithBackoff.new(command, opts)
       command = Masamune::Commands::Shell.new(command, opts)
 

--- a/lib/masamune/actions/hive.rb
+++ b/lib/masamune/actions/hive.rb
@@ -9,7 +9,7 @@ module Masamune::Actions
       opts.merge!(block: block.to_proc) if block_given?
 
       command = Masamune::Commands::Hive.new(context, opts)
-      command = Masamune::Commands::ElasticMapReduce.new(command, opts) if configuration.elastic_mapreduce[:jobflow]
+      command = Masamune::Commands::ElasticMapReduce.new(command, opts.except(:extra)) if configuration.elastic_mapreduce[:jobflow]
       command = Masamune::Commands::LineFormatter.new(command, opts)
       command = Masamune::Commands::RetryWithBackoff.new(command, opts)
       command = Masamune::Commands::Shell.new(command, opts)


### PR DESCRIPTION
The visitation report is currently breaking because of this:
https://jira-projects.socialcast.com/browse/SBI-194
