### PR TITLE
Rename var_dir to run_dir- force run_dir to be defined

### DIFF
--- a/config/masamune.yml.erb
+++ b/config/masamune.yml.erb
@@ -1,5 +1,6 @@
 <%
   add_path :var_dir, get_path(:root_dir, 'var'), :mkdir => true
+  add_path :run_dir, get_path(:var_dir, 'run'), :mkdir => true
   add_path :warehouse_dir, get_path(:var_dir, 'warehouse'), :mkdir => true
 %>
 ---

--- a/lib/masamune/commands/hadoop_streaming.rb
+++ b/lib/masamune/commands/hadoop_streaming.rb
@@ -80,7 +80,7 @@ module Masamune::Commands
     end
 
     def around_execute(&block)
-      Dir.chdir(filesystem.path(:var_dir)) do
+      Dir.chdir(filesystem.path(:run_dir)) do
         yield
       end
     end

--- a/lib/masamune/commands/hive.rb
+++ b/lib/masamune/commands/hive.rb
@@ -75,7 +75,7 @@ module Masamune::Commands
     end
 
     def around_execute(&block)
-      Dir.chdir(filesystem.path(:var_dir)) do
+      Dir.chdir(filesystem.path(:run_dir)) do
         yield
       end
     end

--- a/spec/support/rspec/example/action_example_group.rb
+++ b/spec/support/rspec/example/action_example_group.rb
@@ -1,8 +1,8 @@
 module ActionExampleGroup
   def self.included(base)
-    base.let(:var_dir) { Dir.mktmpdir('masamune') }
+    base.let(:run_dir) { Dir.mktmpdir('masamune') }
     base.before do
-      Masamune.filesystem.add_path(:var_dir, var_dir)
+      Masamune.filesystem.add_path(:run_dir, run_dir)
     end
   end
 end


### PR DESCRIPTION
- Rename `var_dir` to be `run_dir`  to be closer to [FHS](http://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)
- Force `run_dir` to be defined- using a random tmpdir is dangerous
- Fix: https://jira-projects.socialcast.com/browse/SBI-221
