### PR TITLE
Do set PGPASSFILE if not readable

### DIFF
--- a/lib/masamune/commands.rb
+++ b/lib/masamune/commands.rb
@@ -5,6 +5,7 @@ module Masamune
     require 'masamune/commands/hadoop_streaming'
     require 'masamune/commands/hadoop_filesystem'
     require 'masamune/commands/elastic_mapreduce'
+    require 'masamune/commands/postgres_common'
     require 'masamune/commands/postgres'
     require 'masamune/commands/postgres_admin'
     require 'masamune/commands/interactive'

--- a/lib/masamune/commands/postgres.rb
+++ b/lib/masamune/commands/postgres.rb
@@ -5,6 +5,7 @@ module Masamune::Commands
   class Postgres
     include Masamune::ProxyDelegate
     include Masamune::StringFormat
+    include Masamune::Commands::PostgresCommon
 
     DEFAULT_ATTRIBUTES =
     {
@@ -44,11 +45,6 @@ module Masamune::Commands
 
     def print?
       @print
-    end
-
-    # TODO do something if file doesn't exist
-    def command_env
-      @pgpass_file ? {'PGPASSFILE' => @pgpass_file} : {}
     end
 
     def command_args

--- a/lib/masamune/commands/postgres_admin.rb
+++ b/lib/masamune/commands/postgres_admin.rb
@@ -3,6 +3,7 @@ require 'masamune/proxy_delegate'
 module Masamune::Commands
   class PostgresAdmin
     include Masamune::ProxyDelegate
+    include Masamune::Commands::PostgresCommon
 
     DEFAULT_ATTRIBUTES =
     {
@@ -21,11 +22,6 @@ module Masamune::Commands
       DEFAULT_ATTRIBUTES.merge(configuration.postgres).merge(configuration.postgres_admin).merge(attrs).each do |name, value|
         instance_variable_set("@#{name}", value)
       end
-    end
-
-    # TODO do something if file doesn't exist
-    def command_env
-      @pgpass_file ? {'PGPASSFILE' => @pgpass_file} : {}
     end
 
     def command_args

--- a/lib/masamune/commands/postgres_common.rb
+++ b/lib/masamune/commands/postgres_common.rb
@@ -1,0 +1,7 @@
+module Masamune::Commands
+  module PostgresCommon
+    def command_env
+      @pgpass_file && File.readable?(@pgpass_file) ? {'PGPASSFILE' => @pgpass_file} : {}
+    end
+  end
+end

--- a/spec/masamune/commands/postgres_admin_spec.rb
+++ b/spec/masamune/commands/postgres_admin_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'masamune/commands/postgres_common_spec'
 
 describe Masamune::Commands::PostgresAdmin do
   let(:configuration) { {:create_db_path => 'createdb', :drop_db_path => 'dropdb', :hostname => 'localhost', :username => 'postgres'} }
@@ -42,4 +43,6 @@ describe Masamune::Commands::PostgresAdmin do
       it { expect { subject }.to raise_error ArgumentError, ':action must be :create or :drop' }
     end
   end
+
+  it_should_behave_like Masamune::Commands::PostgresCommon
 end

--- a/spec/masamune/commands/postgres_common_spec.rb
+++ b/spec/masamune/commands/postgres_common_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+shared_examples_for Masamune::Commands::PostgresCommon do
+  describe '#command_env' do
+    subject do
+      instance.command_env
+    end
+
+    context 'by default' do
+      it { should == {} }
+    end
+
+    context 'with pgpass_file' do
+      let(:configuration) { {:pgpass_file => 'pgpass_file'} }
+
+      before do
+        File.stub(:readable?) { true }
+      end
+
+      it { should == {'PGPASSFILE' => 'pgpass_file'} }
+    end
+
+    context 'with pgpass_file that is not readable' do
+      let(:configuration) { {:pgpass_file => 'pgpass_file'} }
+
+      before do
+        File.stub(:readable?) { false }
+      end
+
+      it { should == {} }
+    end
+  end
+end

--- a/spec/masamune/commands/postgres_spec.rb
+++ b/spec/masamune/commands/postgres_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'masamune/commands/postgres_common_spec'
 
 describe Masamune::Commands::Postgres do
   let(:configuration) { {:path => 'psql', :database => 'postgres', :options => options} }
@@ -63,4 +64,6 @@ describe Masamune::Commands::Postgres do
       it { should == [*default_command, '--no-align', '--field-separator=,', '--pset=footer'] }
     end
   end
+
+  it_should_behave_like Masamune::Commands::PostgresCommon
 end


### PR DESCRIPTION
`psql` refuses to read a `pgpassfile` unless it's permissions are set to 0600.  By unsetting this environment variable, `psql` will default to loading `$HOME/.pgpassfile` which is required for this chef change:
https://github.com/socialcast/stata-vagrant/pull/22
