### PR TITLE
Force chmod after move to fix issue with Tempfile

### DIFF
--- a/lib/masamune/filesystem.rb
+++ b/lib/masamune/filesystem.rb
@@ -7,6 +7,8 @@ module Masamune
     include Masamune::Actions::S3Cmd
     include Masamune::Actions::HadoopFilesystem
 
+    FILE_MODE = 0777 - File.umask
+
     def initialize
       @paths = {}
       @immutable_paths = {}
@@ -239,6 +241,7 @@ module Masamune
         hadoop_fs('-mv', s3n(src), dst)
       when [:local, :local]
         FileUtils.mv(src, dst, file_util_args)
+        FileUtils.chmod(FILE_MODE, dst, file_util_args)
       when [:local, :hdfs]
         hadoop_fs('-moveFromLocal', src, dst)
       when [:local, :s3]

--- a/spec/masamune/filesystem_spec.rb
+++ b/spec/masamune/filesystem_spec.rb
@@ -517,6 +517,7 @@ shared_examples_for 'Filesystem' do
 
     context 'local file to local file' do
       before do
+        FileUtils.should_receive(:chmod).once
         instance.move_file(old_file, new_file)
       end
 


### PR DESCRIPTION
Parts of the codebase are opening a `Tempfile` as a buffer and using `move_file` as an atomic-write.  Apparently ruby `Tempfile.new` _always_ opens the file in `0600` mode, ignoring the `umask`.  This PR updates `move_file` to always `chmod` with proper `umask`
