### PR TITLE
Fix issue with Filesystem#stat returning an empty Array

### DIFF
--- a/lib/masamune/data_plan_elem.rb
+++ b/lib/masamune/data_plan_elem.rb
@@ -1,5 +1,5 @@
 class Masamune::DataPlanElem
-  MISSING_MODIFIED_AT = -1
+  MISSING_MODIFIED_AT = Time.new(0)
 
   include Masamune::Accumulate
   include Comparable
@@ -34,7 +34,7 @@ class Masamune::DataPlanElem
 
   def last_modified_at
     if rule.for_path?
-      rule.plan.filesystem.stat(path).map(&:mtime).max
+      rule.plan.filesystem.stat(path).map { |stat| stat.try(:mtime) }.compact.max
     elsif rule.for_table?
       rule.plan.postgres_helper.table_last_modified_at(table, @options)
     end || MISSING_MODIFIED_AT

--- a/spec/masamune/data_plan_elem_spec.rb
+++ b/spec/masamune/data_plan_elem_spec.rb
@@ -50,4 +50,40 @@ describe Masamune::DataPlanElem do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#last_modified_at' do
+    let(:early) { Time.parse("2014-05-01 00:00:00 +0000") }
+    let(:later) { Time.parse("2014-06-01 00:00:00 +0000") }
+
+    subject do
+      instance.last_modified_at.utc
+    end
+
+    context 'with missing mtime' do
+      before do
+        expect(rule.plan.filesystem).to receive(:stat).with(instance.path).
+          and_return([[]])
+      end
+
+      it { is_expected.to eq(Masamune::DataPlanElem::MISSING_MODIFIED_AT) }
+    end
+
+    context 'with single mtime' do
+      before do
+        expect(rule.plan.filesystem).to receive(:stat).with(instance.path).
+          and_return([OpenStruct.new(mtime: early)])
+      end
+
+      it { is_expected.to eq(early) }
+    end
+
+    context 'with multiple mtime' do
+      before do
+        expect(rule.plan.filesystem).to receive(:stat).with(instance.path).
+          and_return([OpenStruct.new(mtime: early), OpenStruct.new(mtime: later)])
+      end
+
+      it { is_expected.to eq(later) }
+    end
+  end
 end


### PR DESCRIPTION
Ran into this stack trace while rolling out latest ETL modifications:
https://gist.github.com/mandrews/5b841e5394d3a84e4491

JIRA:
https://jira-projects.socialcast.com/browse/SBI-367
