### PR TITLE
Add work around for Tempfile permissions

### DIFF
--- a/lib/masamune/transform/load_dimension.rb
+++ b/lib/masamune/transform/load_dimension.rb
@@ -14,6 +14,8 @@ module Masamune::Transform
     end
 
     def stage_dimension_as_psql
+      # FIXME move map.apply out of transformation
+      FileUtils.chmod(0777 - File.umask, output.path) if File.exists?(output.path)
       Masamune::Template.render_to_string(stage_dimension_template, source: output.as_table, source_file: output.path)
     end
 


### PR DESCRIPTION
`Tempfile` only opens files in `rw` for process owner (despite file system ACL settings).  In production environment, this tempfile needs to be read by `postgres` user (process is executing as `eventrobot` user). I'm planning to refactor this code so that IO is handled outside of transformation, so that `File` open can be used without leaking resources. This PR is just a temporary workaround to repopulate the reporting database.
