### PR TITLE
Add sub_type to explicitly cast yaml to boolean

### DIFF
--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -3,6 +3,7 @@ require 'json'
 module Masamune::Schema
   class Column
     attr_accessor :type
+    attr_accessor :sub_type
     attr_accessor :null
     attr_accessor :strict
     attr_accessor :default
@@ -14,9 +15,10 @@ module Masamune::Schema
     attr_accessor :parent
     attr_accessor :debug
 
-    def initialize(name: name, type: :integer, null: false, strict: true, default: nil, index: false, unique: false, primary_key: false, surrogate_key: false, reference: nil, parent: nil, debug: false)
+    def initialize(name: name, type: :integer, sub_type: nil, null: false, strict: true, default: nil, index: false, unique: false, primary_key: false, surrogate_key: false, reference: nil, parent: nil, debug: false)
       @name          = name.to_sym
       @type          = type
+      @sub_type      = sub_type
       @null          = null
       @strict        = strict
       @default       = default
@@ -119,7 +121,7 @@ module Masamune::Schema
       when :integer
         value.nil? ? nil : value.to_i
       when :yaml
-        value.nil? ? {} : Hash[YAML.load(value).map { |key, value| [key, ruby_yaml_value(value)] }]
+        value.nil? ? {} : ruby_key_value(YAML.load(value))
       else
         value
       end
@@ -163,14 +165,21 @@ module Masamune::Schema
       self.default = 'uuid_generate_v4()' if primary_key && type == :uuid
     end
 
-    def ruby_yaml_value(value)
-      case value
-      when true, '1'
-        true
-      when false, '0'
-        false
+    def ruby_key_value(hash)
+      case sub_type
+      when :boolean
+        Hash[hash.map { |key, value| ruby_boolean_key_value(key, value) }]
       else
-        value
+        hash
+      end
+    end
+
+    def ruby_boolean_key_value(key, value)
+      case value
+      when true, '1', 1
+        [key, true]
+      when false, '0', 0
+        [key, false]
       end
     end
   end

--- a/spec/masamune/schema/column_spec.rb
+++ b/spec/masamune/schema/column_spec.rb
@@ -4,8 +4,8 @@ describe Masamune::Schema::Column do
   describe '#ruby_value' do
     subject(:result) { column.ruby_value(value) }
 
-    context 'with :yaml type' do
-      let(:column) { described_class.new(name: 'yaml', type: :yaml) }
+    context 'with type :yaml and sub_type :boolean' do
+      let(:column) { described_class.new(name: 'yaml', type: :yaml, sub_type: :boolean) }
       let(:value) do
         {
           'true'         => true,
@@ -23,9 +23,9 @@ describe Masamune::Schema::Column do
         expect(result['false']).to eq(false)
         expect(result['one']).to eq(true)
         expect(result['zero']).to eq(false)
-        expect(result['string']).to eq('string')
-        expect(result['one_integer']).to eq(1)
-        expect(result['zero_integer']).to eq(0)
+        expect(result['one_integer']).to eq(true)
+        expect(result['zero_integer']).to eq(false)
+        expect(result.key?('string')).to eq(false)
       end
     end
   end


### PR DESCRIPTION
While porting YAML to hstore code from ETL- I missed that string values should be explicitly stripped due to encoding issues and their limited usefulness:
https://github.com/socialcast/etl/blob/master/flows/common/hstore_helpers.rb#L5
