### PR TITLE
Add insert annotation to reference instead of table

### DIFF
--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -223,8 +223,8 @@ module Masamune::Schema
       end
     end
 
-    def auto_reference
-      reference && reference.primary_key.auto
+    def auto_reference(insert = false)
+      reference && reference.primary_key.auto && (insert ? !reference.insert : true)
     end
 
     def references?(other)

--- a/lib/masamune/schema/registry.rb
+++ b/lib/masamune/schema/registry.rb
@@ -39,6 +39,7 @@ module Masamune::Schema
     def references(id, options = {})
       @options[:references] << dimensions[id.to_sym].dup.tap do |dimension|
         dimension.label = options[:label]
+        dimension.insert = options[:insert]
       end
     end
 

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -114,7 +114,7 @@ module Masamune::Schema
     end
 
     def upsert_update_columns
-      columns.values.reject { |column| reserved_column_ids.include?(column.id) || column.primary_key || column.surrogate_key || column.unique.any? || column.auto_reference || column.ignore }
+      columns.values.reject { |column| reserved_column_ids.include?(column.id) || column.primary_key || column.surrogate_key || column.unique.any? || column.auto_reference(true) || column.ignore }
     end
     method_with_last_element :upsert_update_columns
 

--- a/lib/masamune/transform/consolidate_dimension.rb
+++ b/lib/masamune/transform/consolidate_dimension.rb
@@ -75,7 +75,7 @@ module Masamune::Transform
     method_with_last_element :insert_view_constraints
 
     def window(*extra)
-      (columns.values.select { |column| extra.delete(column.name) || column.surrogate_key }.map(&:name) + extra).uniq
+      (columns.values.select { |column| extra.delete(column.name) || column.surrogate_key || column.auto_reference }.map(&:name) + extra).uniq
     end
 
     def insert_values(opts = {})

--- a/lib/masamune/transform/relabel_dimension.rb
+++ b/lib/masamune/transform/relabel_dimension.rb
@@ -36,7 +36,7 @@ module Masamune::Transform
     end
 
     def window(*extra)
-      (columns.values.select { |column| extra.delete(column.name) || column.surrogate_key }.map(&:name) + extra).uniq
+      (columns.values.select { |column| extra.delete(column.name) || column.surrogate_key || column.auto_reference }.map(&:name) + extra).uniq
     end
   end
 end

--- a/spec/masamune/transform/load_dimension_spec.rb
+++ b/spec/masamune/transform/load_dimension_spec.rb
@@ -21,7 +21,7 @@ describe Masamune::Transform::LoadDimension do
         row name: 'inactive', description: 'Inactive'
       end
 
-      dimension 'department', type: :mini, insert: true do
+      dimension 'department', type: :mini do
         references :cluster
         column 'uuid', type: :uuid, primary_key: true
         column 'tenant_id', type: :integer, unique: true, surrogate_key: true
@@ -31,7 +31,7 @@ describe Masamune::Transform::LoadDimension do
 
       dimension 'user', type: :four do
         references :cluster
-        references :department
+        references :department, insert: true
         references :user_account_state
         column 'tenant_id', index: true, surrogate_key: true
         column 'user_id', index: true, surrogate_key: true

--- a/spec/masamune/transform/load_fact_spec.rb
+++ b/spec/masamune/transform/load_fact_spec.rb
@@ -11,13 +11,13 @@ describe Masamune::Transform::LoadFact do
         column 'date_id', type: :integer, unique: true, index: true, surrogate_key: true
       end
 
-      dimension 'user_agent', type: :mini, insert: true do
+      dimension 'user_agent', type: :mini do
         column 'name', type: :string, unique: true, index: 'shared'
         column 'version', type: :string, unique: true, index: 'shared', default: 'Unknown'
         column 'description', type: :string, null: true, ignore: true
       end
 
-      dimension  'feature', type: :mini, insert: true do
+      dimension  'feature', type: :mini do
         column  'name', type: :string, unique: true, index: true
       end
 
@@ -34,8 +34,8 @@ describe Masamune::Transform::LoadFact do
         references :date
         references :tenant
         references :user
-        references :user_agent
-        references :feature
+        references :user_agent, insert: true
+        references :feature, insert: true
         measure 'total', type: :integer
       end
 


### PR DESCRIPTION
Change DSL to `insert` on a per `reference` basis instead of a per table basis. Necessary to insert clusters by name when importing tenant_contracts
