### PR TITLE
Safely exit on TERM or HUP

### DIFF
--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -46,6 +46,10 @@ module Masamune
 
       def start(*a)
         super
+      rescue SignalException => e
+        raise e unless %w(SIGHUP SIGTERM).include?(e.to_s)
+        instance.logger.debug("Exiting at user request on #{e.to_s}")
+        exit 0
       rescue => e
         instance.logger.error("#{e.message} (#{e.class}) backtrace:")
         e.backtrace.each { |x| instance.logger.error(x) }


### PR DESCRIPTION
https://jira-projects.socialcast.com/browse/SBI-149

Example: 

``` bash
I, [2014-11-21T17:32:41.760638 #93213]  INFO -- : hive with file /var/folders/bm/bt0bd1rn43lcgnnpzyrc99tr0000gp/T/masamune20141121-93213-mizkkx
I, [2014-11-21T17:32:41.761907 #93213]  INFO -- : copy_file_to_dir with /var/folders/bm/bt0bd1rn43lcgnnpzyrc99tr0000gp/T/masamune20141121-93213-mizkkx /Users/mandrews/Development/etl/tmp/development
D, [2014-11-21T17:32:46.264075 #93213] DEBUG -- :
D, [2014-11-21T17:32:46.264717 #93213] DEBUG -- : Logging initialized using configuration in jar:file:/usr/local/Cellar/hive/0.13.1/libexec/lib/hive-common-0.13.1.jar!/hive-log4j.properties
D, [2014-11-21T17:32:46.474500 #93213] DEBUG -- : 2014-11-21 17:32:46.473 java[93414:13323292] Unable to load realm info from SCDynamicStore
# NOTE sent SIGUP about here 
D, [2014-11-21T17:32:52.461135 #93213] DEBUG -- : OK
D, [2014-11-21T17:32:52.461938 #93213] DEBUG -- : Time taken: 0.539 seconds
D, [2014-11-21T17:32:53.929739 #93213] DEBUG -- : OK
D, [2014-11-21T17:32:53.930523 #93213] DEBUG -- : Time taken: 0.48 seconds
D, [2014-11-21T17:32:54.057669 #93213] DEBUG -- : OK
D, [2014-11-21T17:32:54.058643 #93213] DEBUG -- : Time taken: 0.126 seconds
D, [2014-11-21T17:32:54.168756 #93213] DEBUG -- : OK
D, [2014-11-21T17:32:54.169447 #93213] DEBUG -- : Time taken: 0.11 seconds
D, [2014-11-21T17:32:54.200292 #93213] DEBUG -- : Exiting at user request on SIGHUP
```

Rescuing at this point in the code allows child forked processes such as `hive` to finish execution, while still terminating the parent process as expected
