### PR TITLE
Fix hive boolean encoding

### DIFF
--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -197,7 +197,7 @@ module Masamune::Schema
       return nil if value.nil?
       case type
       when :boolean
-        value ? 'TRUE' : 'FALSE'
+        value ? 'TRUE' : (hive_encoding? ? nil : 'FALSE')
       when :yaml
         value.to_hash.to_yaml
       when :json, :key_value
@@ -313,12 +313,18 @@ module Masamune::Schema
       if type == :json || array_value?
         return true if value == 'NULL'
       end
-      return false unless parent && parent.store
       return false unless value
-      case parent.store.type
-      when :hive
+      if hive_encoding?
         value.to_s == '\N'
-      when :postgres
+      else
+        false
+      end
+    end
+
+    def hive_encoding?
+      if parent && parent.store
+        parent.store.type == :hive
+      else
         false
       end
     end

--- a/spec/masamune/schema/column_spec.rb
+++ b/spec/masamune/schema/column_spec.rb
@@ -427,6 +427,24 @@ describe Masamune::Schema::Column do
       end
     end
 
+    context 'with type :boolean with store :hive' do
+      let(:column) { described_class.new(id: 'bool', type: :boolean) }
+
+      before do
+        allow(column).to receive_message_chain(:parent, :store, :type).and_return(:hive)
+      end
+
+      context 'when true' do
+        let(:value) { true }
+        it { is_expected.to eq('TRUE') }
+      end
+
+      context 'when false' do
+        let(:value) { false }
+        it { is_expected.to eq(nil) }
+      end
+    end
+
     context 'with type :integer and :array' do
       let(:column) { described_class.new(id: 'int[]', type: :integer, array: true) }
 

--- a/spec/masamune/schema/map_spec.rb
+++ b/spec/masamune/schema/map_spec.rb
@@ -282,8 +282,8 @@ describe Masamune::Schema::Map do
 
       let(:target_data) do
         <<-EOS.strip_heredoc
-          1	30		FALSE	{}
-          2	40	2014-02-26T18:15:51.000Z	FALSE	"{""enabled"":true}"
+          1	30			{}
+          2	40	2014-02-26T18:15:51.000Z		"{""enabled"":true}"
         EOS
       end
 


### PR DESCRIPTION
Hive expects `false` to be represented as an empty value for `BOOLEAN` columns