### PR TITLE
Misc AWS Hive 0.13.1 Fixes

### DIFF
--- a/lib/masamune/commands/hive.rb
+++ b/lib/masamune/commands/hive.rb
@@ -102,7 +102,7 @@ module Masamune::Commands
       end
 
       if @output
-        @buffer ||= Tempfile.new('masamune')
+        @buffer = Tempfile.new('masamune')
       end
     end
 
@@ -113,10 +113,12 @@ module Masamune::Commands
     end
 
     def after_execute
-      @buffer.flush if @buffer && @buffer.respond_to?(:flush)
-      @buffer.close if @buffer && @buffer.respond_to?(:close)
+      return unless @buffer
+      @buffer.flush unless @buffer.closed?
+      @buffer.close unless @buffer.closed?
+      return unless @output
 
-      filesystem.move_file_to_file(@buffer.path, @output) if @output && @buffer && @buffer.respond_to?(:path)
+      filesystem.move_file_to_file(@buffer.path, @output)
     end
 
     # FIXME use temporary tables with delimiters for CSV output format

--- a/lib/masamune/environment.rb
+++ b/lib/masamune/environment.rb
@@ -94,7 +94,10 @@ module Masamune
           @log_file_name = filesystem.get_path(:log_dir, log_file_template)
           log_file = File.open(@log_file_name, 'a')
           log_file.sync = true
-          FileUtils.ln_s(log_file, filesystem.path(:log_dir, 'latest'), force: true)
+
+          latest = filesystem.path(:log_dir, 'latest')
+          FileUtils.rm(latest) if File.exists?(latest)
+          FileUtils.ln_s(log_file, latest)
           configuration.debug ? Masamune::MultiIO.new($stderr, log_file) : log_file
         else
           configuration.debug ? $stderr : nil

--- a/lib/masamune/filesystem.rb
+++ b/lib/masamune/filesystem.rb
@@ -553,7 +553,7 @@ module Masamune
         s3cmd('del', src)
       when [:s3, :hdfs]
         hadoop_fs('-mv', s3n(src), dst)
-      when [:local, :local]
+     when [:local, :local]
         FileUtils.mv(src, dst, file_util_args)
         FileUtils.chmod(FILE_MODE, dst, file_util_args)
       when [:local, :hdfs]

--- a/lib/masamune/tasks/hive_thor.rb
+++ b/lib/masamune/tasks/hive_thor.rb
@@ -46,7 +46,8 @@ module Masamune::Tasks
       hive_options = options.dup.with_indifferent_access
       hive_options.merge!(print: true)
       hive_options.merge!(retries: 0) unless options[:retry]
-      hive_options.merge!(file: options[:file])
+      hive_options.merge!(file: File.expand_path(options[:file])) if options[:file]
+      hive_options.merge!(output: File.expand_path(options[:output])) if options[:output]
       hive(hive_options)
     end
     default_task :hive_exec

--- a/lib/masamune/version.rb
+++ b/lib/masamune/version.rb
@@ -21,5 +21,5 @@
 #  THE SOFTWARE.
 
 module Masamune
-  VERSION = '0.10.0.rc1'
+  VERSION = '0.10.0.rc2'
 end

--- a/spec/masamune/tasks/hive_thor_spec.rb
+++ b/spec/masamune/tasks/hive_thor_spec.rb
@@ -43,7 +43,15 @@ describe Masamune::Tasks::HiveThor do
     context 'with --file' do
       let(:options) { ['--file=zombo.hql'] }
       it do
-        expect_any_instance_of(described_class).to receive(:hive).with(hash_including(file: 'zombo.hql')).once.and_return(mock_success)
+        expect_any_instance_of(described_class).to receive(:hive).with(hash_including(file: File.expand_path('zombo.hql'))).once.and_return(mock_success)
+        cli_invocation
+      end
+    end
+
+    context 'with --output' do
+      let(:options) { ['--output=report.txt'] }
+      it do
+        expect_any_instance_of(described_class).to receive(:hive).with(hash_including(output: File.expand_path('report.txt'))).once.and_return(mock_success)
         cli_invocation
       end
     end


### PR DESCRIPTION
- Expand `--file` and `--output` file arguments to absolute paths
- Workaround `FileUtils.ln_s(force: true)` not working
- Do not memoize output buffer so command can be safely executed more than once