### PR TITLE
Stage fact fixes

### DIFF
--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -200,8 +200,10 @@ module Masamune::Schema
       case type
       when :boolean
         value ? 'TRUE' : 'FALSE'
-      when :string, :enum
+      when :string
         "'#{value}'"
+      when :enum
+        "'#{value}'::#{sql_type}"
       else
         value
       end

--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -80,6 +80,8 @@ module Masamune::Schema
         'uuid_generate_v4()'
       when :sequence
         "nextval('#{sequence_id}')"
+      when :enum
+        values.first
       end
     end
 
@@ -169,7 +171,7 @@ module Masamune::Schema
       when :sequence
         'INTEGER'
       when :enum
-        "#{sub_type}_TYPE".upcase
+        "#{sub_type || id}_TYPE".upcase
       when :key_value
         if parent.type == :stage && !parent.inherit
           'JSON'

--- a/lib/masamune/schema/row.rb
+++ b/lib/masamune/schema/row.rb
@@ -100,6 +100,10 @@ module Masamune::Schema
       end
     end
 
+    def sql_value(column)
+      column.sql_value(values[column.name])
+    end
+
     def missing_required_columns
       Set.new.tap do |missing|
         values.select do |key, value|

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -118,7 +118,7 @@ module Masamune::Schema
     def unique_constraints
       return [] if temporary?
       unique_constraints_map.map do |_, column_names|
-        column_names
+        [column_names, short_md5(column_names)]
       end
     end
 
@@ -126,7 +126,7 @@ module Masamune::Schema
     # TODO: Default to GIN for array columns
     def index_columns
       index_column_map.map do |_, column_names|
-        [column_names, reverse_unique_constraints_map.key?(column_names.sort)]
+        [column_names, reverse_unique_constraints_map.key?(column_names.sort), short_md5(column_names)]
       end
     end
 
@@ -299,6 +299,10 @@ module Masamune::Schema
 
     def reverse_unique_constraints_map
       @reverse_unique_constraints_map ||= Hash[unique_constraints_map.to_a.map { |k,v| [v.sort, k] }]
+    end
+
+    def short_md5(*a)
+      Digest::MD5.hexdigest(a.join('_'))[0..6]
     end
   end
 end

--- a/lib/masamune/transform/define_index.psql.erb
+++ b/lib/masamune/transform/define_index.psql.erb
@@ -20,8 +20,8 @@
 --  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 --  THE SOFTWARE.
 
-<%- target.index_columns.each do |column_names, unique| -%>
-<%- index_name = "#{target.name}_#{column_names.join('_')}_index" -%>
+<%- target.index_columns.each do |column_names, unique, id| -%>
+<%- index_name = "#{target.name}_#{id}_index" -%>
 <%- unless target.temporary? -%>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= index_name %>') THEN

--- a/lib/masamune/transform/define_table.psql.erb
+++ b/lib/masamune/transform/define_table.psql.erb
@@ -79,12 +79,14 @@ WHERE NOT EXISTS (SELECT 1 FROM <%= target.name %> WHERE <%= row.insert_constrai
 <%- row.natural_keys.each do |column| -%>
 CREATE OR REPLACE FUNCTION <%= row.name(column) %>
 RETURNS <%= column.sql_type %> IMMUTABLE AS $$
-  SELECT <%= row.values[column.name] %>;
+  SELECT <%= row.sql_value(column) %>;
 $$ LANGUAGE SQL;
+
 <%- end -%>
 
 CREATE OR REPLACE FUNCTION <%= row.name %>
 RETURNS <%= target.surrogate_key.sql_type %> IMMUTABLE AS $$
   SELECT <%= target.surrogate_key.name %> FROM <%= target.name %> WHERE <%= row.insert_constraints.join(' AND ') %>;
 $$ LANGUAGE SQL;
+
 <%- end -%>

--- a/lib/masamune/transform/define_unique.psql.erb
+++ b/lib/masamune/transform/define_unique.psql.erb
@@ -20,8 +20,8 @@
 --  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 --  THE SOFTWARE.
 
-<%- target.unique_constraints.each do |column_names| -%>
-<%- constraint_name = "#{target.name}_#{column_names.join('_')}_key" -%>
+<%- target.unique_constraints.each do |column_names, id| -%>
+<%- constraint_name = "#{target.name}_#{id}_key" -%>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= constraint_name %>') THEN
 ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= constraint_name %> UNIQUE(<%= column_names.join(', ') %>);

--- a/lib/masamune/transform/stage_fact.rb
+++ b/lib/masamune/transform/stage_fact.rb
@@ -75,12 +75,10 @@ module Masamune::Transform
               coalesce_values << cross_references.map { |_, column| column.qualified_name }
             end
 
-            if column.adjacent.try(:default)
-              coalesce_values << column.adjacent.sql_value(column.adjacent.try(:default))
-            end
-
             if column.reference && column.reference.default
               coalesce_values << column.reference.default(column.adjacent) if column.adjacent.natural_key
+            elsif column.adjacent.try(:default)
+              coalesce_values << column.adjacent.sql_value(column.adjacent.try(:default))
             end
 
             conditions[reference.name] << (coalesce_values.any? ?

--- a/lib/masamune/transform/stage_fact.rb
+++ b/lib/masamune/transform/stage_fact.rb
@@ -75,10 +75,10 @@ module Masamune::Transform
               coalesce_values << cross_references.map { |_, column| column.qualified_name }
             end
 
-            if column.reference && column.reference.default
+            if column.reference && !column.reference.default.nil?
               coalesce_values << column.reference.default(column.adjacent) if column.adjacent.natural_key
-            elsif column.adjacent.try(:default)
-              coalesce_values << column.adjacent.sql_value(column.adjacent.try(:default))
+            elsif !column.adjacent.default.nil?
+              coalesce_values << column.adjacent.sql_value(column.adjacent.default)
             end
 
             conditions[reference.name] << (coalesce_values.any? ?

--- a/spec/masamune/schema/column_spec.rb
+++ b/spec/masamune/schema/column_spec.rb
@@ -60,6 +60,38 @@ describe Masamune::Schema::Column do
       end
     end
 
+    context 'with type :enum' do
+      subject(:column) { described_class.new(id: 'mode', type: :enum, values: %w(public private)) }
+
+      context '#default' do
+        subject { column.default }
+        it { is_expected.to eq('public') }
+      end
+
+      context '#sql_type' do
+        subject { column.sql_type }
+        it { is_expected.to eq('MODE_TYPE') }
+      end
+
+      context 'with :sub_type' do
+        subject(:column) { described_class.new(id: 'permission', type: :enum, sub_type: 'mode') }
+
+        context '#sql_type' do
+          subject { column.sql_type }
+          it { is_expected.to eq('MODE_TYPE') }
+        end
+      end
+
+      context 'with :default' do
+        subject(:column) { described_class.new(id: 'mode', type: :enum, values: %w(public private), default: 'private') }
+
+        context '#default' do
+          subject { column.default }
+          it { is_expected.to eq('private') }
+        end
+      end
+    end
+
     context 'with index: false' do
       subject(:column) { described_class.new(id: 'id', index: false) }
       context '#index' do

--- a/spec/masamune/transform/define_table.dimension_spec.rb
+++ b/spec/masamune/transform/define_table.dimension_spec.rb
@@ -92,33 +92,33 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_tenant_id_user_id_start_at_key') THEN
-        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_tenant_id_user_id_start_at_key UNIQUE(tenant_id, user_id, start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_key') THEN
+        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_e6c3d91_key UNIQUE(tenant_id, user_id, start_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_tenant_id_index') THEN
-        CREATE INDEX user_dimension_tenant_id_index ON user_dimension (tenant_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
+        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_user_id_index') THEN
-        CREATE INDEX user_dimension_user_id_index ON user_dimension (user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e8701ad_index') THEN
+        CREATE INDEX user_dimension_e8701ad_index ON user_dimension (user_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_start_at_index') THEN
-        CREATE INDEX user_dimension_start_at_index ON user_dimension (start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_23563d3_index') THEN
+        CREATE INDEX user_dimension_23563d3_index ON user_dimension (start_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_end_at_index') THEN
-        CREATE INDEX user_dimension_end_at_index ON user_dimension (end_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2c8e908_index') THEN
+        CREATE INDEX user_dimension_2c8e908_index ON user_dimension (end_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_version_index') THEN
-        CREATE INDEX user_dimension_version_index ON user_dimension (version);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2af72f1_index') THEN
+        CREATE INDEX user_dimension_2af72f1_index ON user_dimension (version);
         END IF; END $$;
       EOS
     end
@@ -162,28 +162,28 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_tenant_id_user_id_source_kind_source_uuid_start_at_key') THEN
-        ALTER TABLE user_dimension_ledger ADD CONSTRAINT user_dimension_ledger_tenant_id_user_id_source_kind_source_uuid_start_at_key UNIQUE(tenant_id, user_id, source_kind, source_uuid, start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_370d6dd_key') THEN
+        ALTER TABLE user_dimension_ledger ADD CONSTRAINT user_dimension_ledger_370d6dd_key UNIQUE(tenant_id, user_id, source_kind, source_uuid, start_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_user_account_state_type_id_index') THEN
-        CREATE INDEX user_dimension_ledger_user_account_state_type_id_index ON user_dimension_ledger (user_account_state_type_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_7988187_index') THEN
+        CREATE INDEX user_dimension_ledger_7988187_index ON user_dimension_ledger (user_account_state_type_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_tenant_id_index') THEN
-        CREATE INDEX user_dimension_ledger_tenant_id_index ON user_dimension_ledger (tenant_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_3854361_index') THEN
+        CREATE INDEX user_dimension_ledger_3854361_index ON user_dimension_ledger (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_user_id_index') THEN
-        CREATE INDEX user_dimension_ledger_user_id_index ON user_dimension_ledger (user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_e8701ad_index') THEN
+        CREATE INDEX user_dimension_ledger_e8701ad_index ON user_dimension_ledger (user_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_start_at_index') THEN
-        CREATE INDEX user_dimension_ledger_start_at_index ON user_dimension_ledger (start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_23563d3_index') THEN
+        CREATE INDEX user_dimension_ledger_23563d3_index ON user_dimension_ledger (start_at);
         END IF; END $$;
 
         CREATE TABLE IF NOT EXISTS user_dimension
@@ -202,38 +202,38 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_tenant_id_user_id_start_at_key') THEN
-        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_tenant_id_user_id_start_at_key UNIQUE(tenant_id, user_id, start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_key') THEN
+        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_e6c3d91_key UNIQUE(tenant_id, user_id, start_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_user_account_state_type_id_index') THEN
-        CREATE INDEX user_dimension_user_account_state_type_id_index ON user_dimension (user_account_state_type_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_7988187_index') THEN
+        CREATE INDEX user_dimension_7988187_index ON user_dimension (user_account_state_type_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_tenant_id_index') THEN
-        CREATE INDEX user_dimension_tenant_id_index ON user_dimension (tenant_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
+        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_user_id_index') THEN
-        CREATE INDEX user_dimension_user_id_index ON user_dimension (user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e8701ad_index') THEN
+        CREATE INDEX user_dimension_e8701ad_index ON user_dimension (user_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_start_at_index') THEN
-        CREATE INDEX user_dimension_start_at_index ON user_dimension (start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_23563d3_index') THEN
+        CREATE INDEX user_dimension_23563d3_index ON user_dimension (start_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_end_at_index') THEN
-        CREATE INDEX user_dimension_end_at_index ON user_dimension (end_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2c8e908_index') THEN
+        CREATE INDEX user_dimension_2c8e908_index ON user_dimension (end_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_version_index') THEN
-        CREATE INDEX user_dimension_version_index ON user_dimension (version);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2af72f1_index') THEN
+        CREATE INDEX user_dimension_2af72f1_index ON user_dimension (version);
         END IF; END $$;
       EOS
     end
@@ -275,12 +275,12 @@ describe Masamune::Transform::DefineTable do
           last_modified_at TIMESTAMP DEFAULT NOW()
         );
 
-        CREATE INDEX user_consolidated_forward_dimension_stage_user_account_state_type_id_index ON user_consolidated_forward_dimension_stage (user_account_state_type_id);
-        CREATE INDEX user_consolidated_forward_dimension_stage_tenant_id_index ON user_consolidated_forward_dimension_stage (tenant_id);
-        CREATE INDEX user_consolidated_forward_dimension_stage_user_id_index ON user_consolidated_forward_dimension_stage (user_id);
-        CREATE INDEX user_consolidated_forward_dimension_stage_start_at_index ON user_consolidated_forward_dimension_stage (start_at);
-        CREATE INDEX user_consolidated_forward_dimension_stage_end_at_index ON user_consolidated_forward_dimension_stage (end_at);
-        CREATE INDEX user_consolidated_forward_dimension_stage_version_index ON user_consolidated_forward_dimension_stage (version);
+        CREATE INDEX user_consolidated_forward_dimension_stage_7988187_index ON user_consolidated_forward_dimension_stage (user_account_state_type_id);
+        CREATE INDEX user_consolidated_forward_dimension_stage_3854361_index ON user_consolidated_forward_dimension_stage (tenant_id);
+        CREATE INDEX user_consolidated_forward_dimension_stage_e8701ad_index ON user_consolidated_forward_dimension_stage (user_id);
+        CREATE INDEX user_consolidated_forward_dimension_stage_23563d3_index ON user_consolidated_forward_dimension_stage (start_at);
+        CREATE INDEX user_consolidated_forward_dimension_stage_2c8e908_index ON user_consolidated_forward_dimension_stage (end_at);
+        CREATE INDEX user_consolidated_forward_dimension_stage_2af72f1_index ON user_consolidated_forward_dimension_stage (version);
       EOS
     end
   end

--- a/spec/masamune/transform/define_table.fact_spec.rb
+++ b/spec/masamune/transform/define_table.fact_spec.rb
@@ -136,43 +136,43 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_cluster_type_id_index') THEN
-        CREATE INDEX visits_fact_cluster_type_id_index ON visits_fact (cluster_type_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_d6b9b38_index') THEN
+        CREATE INDEX visits_fact_d6b9b38_index ON visits_fact (cluster_type_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_date_dimension_id_index') THEN
-        CREATE INDEX visits_fact_date_dimension_id_index ON visits_fact (date_dimension_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_0a531a8_index') THEN
+        CREATE INDEX visits_fact_0a531a8_index ON visits_fact (date_dimension_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_tenant_dimension_id_index') THEN
-        CREATE INDEX visits_fact_tenant_dimension_id_index ON visits_fact (tenant_dimension_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_d3950d9_index') THEN
+        CREATE INDEX visits_fact_d3950d9_index ON visits_fact (tenant_dimension_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_user_dimension_id_index') THEN
-        CREATE INDEX visits_fact_user_dimension_id_index ON visits_fact (user_dimension_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_39f0fdd_index') THEN
+        CREATE INDEX visits_fact_39f0fdd_index ON visits_fact (user_dimension_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_group_dimension_id_index') THEN
-        CREATE INDEX visits_fact_group_dimension_id_index ON visits_fact (group_dimension_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_e0d2a9e_index') THEN
+        CREATE INDEX visits_fact_e0d2a9e_index ON visits_fact (group_dimension_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_user_agent_type_id_index') THEN
-        CREATE INDEX visits_fact_user_agent_type_id_index ON visits_fact (user_agent_type_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_d8b1c3e_index') THEN
+        CREATE INDEX visits_fact_d8b1c3e_index ON visits_fact (user_agent_type_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_feature_type_id_index') THEN
-        CREATE INDEX visits_fact_feature_type_id_index ON visits_fact (feature_type_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_33b68fd_index') THEN
+        CREATE INDEX visits_fact_33b68fd_index ON visits_fact (feature_type_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_time_key_index') THEN
-        CREATE INDEX visits_fact_time_key_index ON visits_fact (time_key);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_6444ed3_index') THEN
+        CREATE INDEX visits_fact_6444ed3_index ON visits_fact (time_key);
         END IF; END $$;
       EOS
     end
@@ -203,13 +203,13 @@ describe Masamune::Transform::DefineTable do
         COPY visits_file_fact_stage FROM 'output_2.csv' WITH (FORMAT 'csv', HEADER true);
         COPY visits_file_fact_stage FROM 'output_3.csv' WITH (FORMAT 'csv', HEADER true);
 
-        CREATE INDEX visits_file_fact_stage_date_dimension_date_id_index ON visits_file_fact_stage (date_dimension_date_id);
-        CREATE INDEX visits_file_fact_stage_tenant_dimension_tenant_id_index ON visits_file_fact_stage (tenant_dimension_tenant_id);
-        CREATE INDEX visits_file_fact_stage_user_dimension_user_id_index ON visits_file_fact_stage (user_dimension_user_id);
-        CREATE INDEX visits_file_fact_stage_user_agent_type_name_index ON visits_file_fact_stage (user_agent_type_name);
-        CREATE INDEX visits_file_fact_stage_user_agent_type_version_index ON visits_file_fact_stage (user_agent_type_version);
-        CREATE INDEX visits_file_fact_stage_feature_type_name_index ON visits_file_fact_stage (feature_type_name);
-        CREATE INDEX visits_file_fact_stage_time_key_index ON visits_file_fact_stage (time_key);
+        CREATE INDEX visits_file_fact_stage_964dac1_index ON visits_file_fact_stage (date_dimension_date_id);
+        CREATE INDEX visits_file_fact_stage_90fc13c_index ON visits_file_fact_stage (tenant_dimension_tenant_id);
+        CREATE INDEX visits_file_fact_stage_30f3cca_index ON visits_file_fact_stage (user_dimension_user_id);
+        CREATE INDEX visits_file_fact_stage_99c433b_index ON visits_file_fact_stage (user_agent_type_name);
+        CREATE INDEX visits_file_fact_stage_d5d236f_index ON visits_file_fact_stage (user_agent_type_version);
+        CREATE INDEX visits_file_fact_stage_5a187ed_index ON visits_file_fact_stage (feature_type_name);
+        CREATE INDEX visits_file_fact_stage_6444ed3_index ON visits_file_fact_stage (time_key);
       EOS
     end
 
@@ -254,13 +254,13 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_message_kind_type_id_index') THEN
-        CREATE INDEX visits_fact_message_kind_type_id_index ON visits_fact (message_kind_type_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_2a6313d_index') THEN
+        CREATE INDEX visits_fact_2a6313d_index ON visits_fact (message_kind_type_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_time_key_index') THEN
-        CREATE INDEX visits_fact_time_key_index ON visits_fact (time_key);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_6444ed3_index') THEN
+        CREATE INDEX visits_fact_6444ed3_index ON visits_fact (time_key);
         END IF; END $$;
       EOS
     end

--- a/spec/masamune/transform/define_table.table_spec.rb
+++ b/spec/masamune/transform/define_table.table_spec.rb
@@ -71,13 +71,13 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_tenant_id_index') THEN
-        CREATE INDEX user_table_tenant_id_index ON user_table (tenant_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
+        CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_user_id_index') THEN
-        CREATE INDEX user_table_user_id_index ON user_table (user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_index') THEN
+        CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
         END IF; END $$;
       EOS
     end
@@ -105,18 +105,18 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_tenant_id_index') THEN
-        CREATE INDEX user_table_tenant_id_index ON user_table (tenant_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
+        CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_user_id_index') THEN
-        CREATE INDEX user_table_user_id_index ON user_table (user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_index') THEN
+        CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_tenant_id_user_id_index') THEN
-        CREATE INDEX user_table_tenant_id_user_id_index ON user_table (tenant_id, user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_index') THEN
+        CREATE INDEX user_table_e0e4295_index ON user_table (tenant_id, user_id);
         END IF; END $$;
       EOS
     end
@@ -144,13 +144,13 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_user_id_key') THEN
-        ALTER TABLE user_table ADD CONSTRAINT user_table_user_id_key UNIQUE(user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_key') THEN
+        ALTER TABLE user_table ADD CONSTRAINT user_table_e8701ad_key UNIQUE(user_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_tenant_id_user_id_key') THEN
-        ALTER TABLE user_table ADD CONSTRAINT user_table_tenant_id_user_id_key UNIQUE(tenant_id, user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_key') THEN
+        ALTER TABLE user_table ADD CONSTRAINT user_table_e0e4295_key UNIQUE(tenant_id, user_id);
         END IF; END $$;
       EOS
     end
@@ -266,13 +266,13 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_tenant_id_user_id_key') THEN
-        ALTER TABLE user_table ADD CONSTRAINT user_table_tenant_id_user_id_key UNIQUE(tenant_id, user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_key') THEN
+        ALTER TABLE user_table ADD CONSTRAINT user_table_e0e4295_key UNIQUE(tenant_id, user_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_tenant_id_user_id_index') THEN
-        CREATE UNIQUE INDEX user_table_tenant_id_user_id_index ON user_table (tenant_id, user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_index') THEN
+        CREATE UNIQUE INDEX user_table_e0e4295_index ON user_table (tenant_id, user_id);
         END IF; END $$;
       EOS
     end
@@ -302,8 +302,8 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_tenant_id_user_id_key') THEN
-        ALTER TABLE user_table ADD CONSTRAINT user_table_tenant_id_user_id_key UNIQUE(tenant_id, user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_key') THEN
+        ALTER TABLE user_table ADD CONSTRAINT user_table_e0e4295_key UNIQUE(tenant_id, user_id);
         END IF; END $$;
 
         INSERT INTO user_table (tenant_id, user_id)
@@ -367,8 +367,8 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_user_account_state_table_id_index') THEN
-        CREATE INDEX user_table_user_account_state_table_id_index ON user_table (user_account_state_table_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_bd2027e_index') THEN
+        CREATE INDEX user_table_bd2027e_index ON user_table (user_account_state_table_id);
         END IF; END $$;
       EOS
     end
@@ -404,13 +404,13 @@ describe Masamune::Transform::DefineTable do
         );
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_user_account_state_table_id_index') THEN
-        CREATE INDEX user_table_user_account_state_table_id_index ON user_table (user_account_state_table_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_bd2027e_index') THEN
+        CREATE INDEX user_table_bd2027e_index ON user_table (user_account_state_table_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_hr_user_account_state_table_id_index') THEN
-        CREATE INDEX user_table_hr_user_account_state_table_id_index ON user_table (hr_user_account_state_table_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_074da4a_index') THEN
+        CREATE INDEX user_table_074da4a_index ON user_table (hr_user_account_state_table_id);
         END IF; END $$;
       EOS
     end
@@ -447,8 +447,8 @@ describe Masamune::Transform::DefineTable do
             name VARCHAR
           );
 
-          CREATE INDEX user_table_stage_user_account_state_table_id_index ON user_table_stage (user_account_state_table_id);
-          CREATE INDEX user_table_stage_hr_user_account_state_table_id_index ON user_table_stage (hr_user_account_state_table_id);
+          CREATE INDEX user_table_stage_bd2027e_index ON user_table_stage (user_account_state_table_id);
+          CREATE INDEX user_table_stage_074da4a_index ON user_table_stage (hr_user_account_state_table_id);
         EOS
       end
     end
@@ -465,8 +465,8 @@ describe Masamune::Transform::DefineTable do
             name VARCHAR
           );
 
-          CREATE INDEX user_table_stage_hr_user_account_state_table_id_index ON user_table_stage (hr_user_account_state_table_id);
-          CREATE INDEX user_table_stage_user_account_state_table_id_index ON user_table_stage (user_account_state_table_id);
+          CREATE INDEX user_table_stage_074da4a_index ON user_table_stage (hr_user_account_state_table_id);
+          CREATE INDEX user_table_stage_bd2027e_index ON user_table_stage (user_account_state_table_id);
         EOS
       end
     end

--- a/spec/masamune/transform/define_table.table_spec.rb
+++ b/spec/masamune/transform/define_table.table_spec.rb
@@ -181,7 +181,7 @@ describe Masamune::Transform::DefineTable do
           id SERIAL PRIMARY KEY,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL,
-          state USER_STATE_TYPE NOT NULL DEFAULT 'active'
+          state USER_STATE_TYPE NOT NULL DEFAULT 'active'::USER_STATE_TYPE
         );
       EOS
     end

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -44,6 +44,7 @@ describe Masamune::Transform::StageFact do
 
       dimension 'feature', type: :mini do
         column 'name', type: :string, unique: true, index: true
+        row name: 'unknown', attributes: {default: true}
       end
 
       dimension 'tenant', type: :two do

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -39,6 +39,7 @@ describe Masamune::Transform::StageFact do
       dimension 'user_agent', type: :mini do
         column 'name', type: :string, unique: true, index: 'shared'
         column 'version', type: :string, unique: true, index: 'shared', default: 'Unknown'
+        column 'mobile', type: :boolean, unique: true, index: 'shared', default: false
         column 'description', type: :string, null: true, ignore: true
       end
 
@@ -81,6 +82,7 @@ describe Masamune::Transform::StageFact do
         column 'group.group_mode', type: :enum, sub_type: 'group_mode'
         column 'user_agent.name', type: :string
         column 'user_agent.version', type: :string
+        column 'user_agent.mobile', type: :boolean
         column 'feature.name', type: :string
         column 'session.id', type: :integer
         column 'time_key', type: :integer
@@ -150,7 +152,8 @@ describe Masamune::Transform::StageFact do
           user_agent_type
         ON
           user_agent_type.name = visits_hourly_file_fact_stage.user_agent_type_name AND
-          user_agent_type.version = COALESCE(visits_hourly_file_fact_stage.user_agent_type_version, 'Unknown')
+          user_agent_type.version = COALESCE(visits_hourly_file_fact_stage.user_agent_type_version, 'Unknown') AND
+          user_agent_type.mobile = COALESCE(visits_hourly_file_fact_stage.user_agent_type_mobile, FALSE)
         JOIN
           feature_type
         ON

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -58,7 +58,8 @@ describe Masamune::Transform::StageFact do
 
       dimension 'group', type: :two do
         column 'group_id', type: :integer, index: true, natural_key: true
-        row group_id: -1, attributes: {id: :missing}
+        column 'group_mode', type: :enum, sub_type: 'group_mode', values: %(missing public private), index: true, natural_key: true, default: 'missing'
+        row group_id: -1, group_mode: 'missing', attributes: {id: :missing}
       end
 
       fact 'visits', partition: 'y%Ym%m', grain: %w(hourly daily monthly) do
@@ -78,6 +79,7 @@ describe Masamune::Transform::StageFact do
         column 'tenant.tenant_id', type: :integer
         column 'user.user_id', type: :integer
         column 'group.group_id', type: :integer
+        column 'group.group_mode', type: :enum, sub_type: 'group_mode'
         column 'user_agent.name', type: :string
         column 'user_agent.version', type: :string
         column 'feature.name', type: :string
@@ -143,6 +145,7 @@ describe Masamune::Transform::StageFact do
           group_dimension
         ON
           group_dimension.group_id = COALESCE(visits_hourly_file_fact_stage.group_dimension_group_id, missing_group_id()) AND
+          group_dimension.group_mode = COALESCE(visits_hourly_file_fact_stage.group_dimension_group_mode, missing_group_mode()) AND
           ((TO_TIMESTAMP(visits_hourly_file_fact_stage.time_key) BETWEEN group_dimension.start_at AND COALESCE(group_dimension.end_at, 'INFINITY')) OR (TO_TIMESTAMP(visits_hourly_file_fact_stage.time_key) < group_dimension.start_at AND group_dimension.version = 1))
         JOIN
           user_agent_type

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -44,7 +44,6 @@ describe Masamune::Transform::StageFact do
 
       dimension 'feature', type: :mini do
         column 'name', type: :string, unique: true, index: true
-        row name: 'unknown', attributes: {default: true}
       end
 
       dimension 'tenant', type: :two do


### PR DESCRIPTION
- Generate index and foreign key constraint names using md5 (long names were overflowing postgres `NAMEDATALEN`)
- Add some sane defaults for `enum` type
  - Subtype is implicitly `column.id`
  - Default value is first value
- Fix stage fact join on `enum` and `boolean` columns