### PR TITLE
Add --init flag

### DIFF
--- a/lib/masamune/actions/elastic_mapreduce.rb
+++ b/lib/masamune/actions/elastic_mapreduce.rb
@@ -54,6 +54,7 @@ module Masamune::Actions
     included do |base|
       base.class_option :jobflow, :aliases => '-j', :desc => 'Elastic MapReduce jobflow ID (Hint: elastic-mapreduce --list)' if defined?(base.class_option)
       base.after_initialize(:early) do |thor, options|
+        next unless options[:initialize]
         next if thor.configuration.elastic_mapreduce.empty?
         next unless thor.configuration.elastic_mapreduce.fetch(:enabled, true)
         jobflow = thor.resolve_jobflow(options[:jobflow] || thor.configuration.elastic_mapreduce[:jobflow])

--- a/lib/masamune/actions/execute.rb
+++ b/lib/masamune/actions/execute.rb
@@ -46,7 +46,7 @@ module Masamune::Actions
       end if block_given?
 
       command = Masamune::Commands::Shell.new(klass.new(self), {fail_fast: false}.merge(opts))
-      opts.fetch(:interactive, true) ? command.execute : command.replace(opts)
+      opts.fetch(:interactive, false) ? command.replace(opts) : command.execute
     end
   end
 end

--- a/lib/masamune/actions/hive.rb
+++ b/lib/masamune/actions/hive.rb
@@ -63,11 +63,14 @@ module Masamune::Actions
 
     included do |base|
       base.after_initialize do |thor, options|
+        next unless options[:initialize]
         thor.create_hive_database_if_not_exists
-        if options[:dry_run]
-          raise ::Thor::InvocationError, 'Dry run of hive failed' unless thor.hive(exec: 'SHOW TABLES;', safe: true, fail_fast: false).success?
-        end
         thor.load_hive_schema
+      end if defined?(base.after_initialize)
+
+      base.after_initialize(:later) do |thor, options|
+        next unless options[:dry_run]
+        raise ::Thor::InvocationError, 'Dry run of hive failed' unless thor.hive(exec: 'SHOW TABLES;', safe: true, fail_fast: false).success?
       end if defined?(base.after_initialize)
     end
   end

--- a/lib/masamune/actions/invoke_parallel.rb
+++ b/lib/masamune/actions/invoke_parallel.rb
@@ -40,7 +40,7 @@ module Masamune::Actions
       bail_fast task_group, opts if opts[:version]
       Parallel.each(task_group, in_processes: max_tasks) do |task_name|
         begin
-          execute(thor_wrapper, task_name, *task_args(opts), interactive: false, detach: false)
+          execute(thor_wrapper, task_name, *task_args(opts), interactive: true, detach: false)
         rescue SystemExit
         end
       end

--- a/lib/masamune/actions/postgres.rb
+++ b/lib/masamune/actions/postgres.rb
@@ -67,6 +67,7 @@ module Masamune::Actions
 
     included do |base|
       base.after_initialize do |thor, options|
+        next unless options[:initialize]
         thor.create_postgres_database_if_not_exists
         thor.load_postgres_setup_files
         thor.load_postgres_schema

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -101,6 +101,7 @@ module Masamune
         class_option :config, :desc => 'Configuration file'
         class_option :version, :desc => 'Print version and exit', :type => :boolean
         class_option :lock, :desc => 'Optional job lock name', :type => :string
+        class_option :initialize, :aliases => '--init', :desc => 'Initialize configured data stores', :type => :boolean, :default => false
         class_option :'--', :desc => 'Extra pass through arguments'
         def initialize(_args=[], _options={}, _config={})
           self.environment.parent = self

--- a/spec/masamune/actions/elastic_mapreduce_spec.rb
+++ b/spec/masamune/actions/elastic_mapreduce_spec.rb
@@ -51,7 +51,7 @@ describe Masamune::Actions::ElasticMapreduce do
   end
 
   describe '.after_initialize' do
-    let(:options) { {} }
+    let(:options) { {initialize: true} }
 
     subject(:after_initialize_invoke) do
       instance.after_initialize_invoke(options)
@@ -72,9 +72,18 @@ describe Masamune::Actions::ElasticMapreduce do
       it { expect { subject }.to raise_error Thor::RequiredArgumentMissingError, /No value provided for required options '--jobflow'/ }
     end
 
-    context 'when jobflow does not exist' do
+    context 'when jobflow is present without initialize' do
       let(:configuration) { {enabled: true} }
       let(:options) { {jobflow: 'j-XYZ'} }
+      before do
+        expect(instance).to_not receive(:elastic_mapreduce)
+      end
+      it { expect { subject }.to_not raise_error }
+    end
+
+    context 'when jobflow does not exist' do
+      let(:configuration) { {enabled: true} }
+      let(:options) { {initialize: true, jobflow: 'j-XYZ'} }
       before do
         mock_command(/\Aelastic-mapreduce/, mock_failure)
       end
@@ -83,7 +92,7 @@ describe Masamune::Actions::ElasticMapreduce do
 
     context 'when jobflow exists' do
       let(:configuration) { {enabled: true} }
-      let(:options) { {jobflow: 'j-XYZ'} }
+      let(:options) { {initialize: true, jobflow: 'j-XYZ'} }
       before do
         mock_command(/\Aelastic-mapreduce/, mock_success)
       end
@@ -95,7 +104,7 @@ describe Masamune::Actions::ElasticMapreduce do
 
     context 'when jobflow is symbolic' do
       let(:configuration) { {enabled: true, jobflows: {'build' => 'j-XYZ'}} }
-      let(:options) { {jobflow: 'build', } }
+      let(:options) { {initialize: true, jobflow: 'build', } }
       before do
         mock_command(/\Aelastic-mapreduce/, mock_success)
       end

--- a/spec/masamune/actions/hive_spec.rb
+++ b/spec/masamune/actions/hive_spec.rb
@@ -68,11 +68,20 @@ describe Masamune::Actions::Hive do
   end
 
   describe '.after_initialize' do
-    let(:options) { {} }
+    let(:options) { {initialize: true} }
     let(:configuration) { {database: 'test'} }
 
     subject(:after_initialize_invoke) do
       instance.after_initialize_invoke(options)
+    end
+
+    context 'without --initialize' do
+      let(:options) { {} }
+      before do
+        expect(instance).to_not receive(:hive)
+        after_initialize_invoke
+      end
+      it 'should not call hive' do; end
     end
 
     context 'with default database' do
@@ -103,12 +112,12 @@ describe Masamune::Actions::Hive do
       it 'should call hive with create database' do; end
     end
 
-    context 'with dryrun' do
-      let(:options) { {dry_run: true} }
+    context 'with dry_run' do
+      let(:options) { {initialize: true, dry_run: true} }
       before do
         expect(instance).to receive(:hive).with(exec: 'CREATE DATABASE IF NOT EXISTS test;', :database => nil).once.and_return(mock_success)
-        expect(instance).to receive(:hive).with(exec: 'SHOW TABLES;', safe: true, fail_fast: false).once.and_return(mock_success)
         expect(instance).to receive(:hive).with(file: an_instance_of(String)).once.and_return(mock_success)
+        expect(instance).to receive(:hive).with(exec: 'SHOW TABLES;', safe: true, fail_fast: false).once.and_return(mock_success)
         after_initialize_invoke
       end
       it 'should call hive with show tables' do; end

--- a/spec/masamune/actions/postgres_spec.rb
+++ b/spec/masamune/actions/postgres_spec.rb
@@ -58,13 +58,23 @@ describe Masamune::Actions::Postgres do
   end
 
   describe '.after_initialize' do
-    let(:options) { {} }
+    let(:options) { {initialize: true} }
     let(:setup_files) { [] }
     let(:schema_files) { [] }
     let(:configuration) { {database: 'test', setup_files: setup_files, schema_files: schema_files} }
 
     subject(:after_initialize_invoke) do
       instance.after_initialize_invoke(options)
+    end
+
+    context 'without --initialize' do
+      let(:options) { {} }
+      before do
+        expect(instance).to_not receive(:postgres_admin)
+        expect(instance).to_not receive(:postgres)
+        after_initialize_invoke
+      end
+      it 'should not call postgres_admin or postgres' do; end
     end
 
     context 'when database does not exist' do

--- a/spec/masamune/tasks/hive_thor_spec.rb
+++ b/spec/masamune/tasks/hive_thor_spec.rb
@@ -34,42 +34,45 @@ describe Masamune::Tasks::HiveThor do
     it_behaves_like 'command usage'
   end
 
-  context 'with command options' do
-    before do
+  context 'with --file and --initialize' do
+    let(:options) { ['--file=zombo.hql', '--initialize'] }
+    it do
       expect_any_instance_of(described_class).to receive(:hive).with(exec: 'CREATE DATABASE IF NOT EXISTS masamune;', database: nil).and_return(mock_success)
       expect_any_instance_of(described_class).to receive(:hive).with(file: instance_of(String)).and_return(mock_success)
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_including(file: File.expand_path('zombo.hql'))).once.and_return(mock_success)
+      cli_invocation
     end
+  end
 
-    context 'with --file' do
-      let(:options) { ['--file=zombo.hql'] }
-      it do
-        expect_any_instance_of(described_class).to receive(:hive).with(hash_including(file: File.expand_path('zombo.hql'))).once.and_return(mock_success)
-        cli_invocation
-      end
+  context 'with --file' do
+    let(:options) { ['--file=zombo.hql'] }
+    it do
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_including(file: File.expand_path('zombo.hql'))).once.and_return(mock_success)
+      cli_invocation
     end
+  end
 
-    context 'with --output' do
-      let(:options) { ['--output=report.txt'] }
-      it do
-        expect_any_instance_of(described_class).to receive(:hive).with(hash_including(output: File.expand_path('report.txt'))).once.and_return(mock_success)
-        cli_invocation
-      end
+  context 'with --output' do
+    let(:options) { ['--output=report.txt'] }
+    it do
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_including(output: File.expand_path('report.txt'))).once.and_return(mock_success)
+      cli_invocation
     end
+  end
 
-    context 'with --variables=YEAR:2015 MONTH:1' do
-      let(:options) { ['--variables=YEAR:2015', 'MONTH:1'] }
-      it do
-        expect_any_instance_of(described_class).to receive(:hive).with(hash_including(variables: { 'YEAR' => '2015', 'MONTH' => '1'})).once.and_return(mock_success)
-        cli_invocation
-      end
+  context 'with --variables=YEAR:2015 MONTH:1' do
+    let(:options) { ['--variables=YEAR:2015', 'MONTH:1'] }
+    it do
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_including(variables: { 'YEAR' => '2015', 'MONTH' => '1'})).once.and_return(mock_success)
+      cli_invocation
     end
+  end
 
-    context 'with -X YEAR:2015 MONTH:1' do
-      let(:options) { ['-X', 'YEAR:2015', 'MONTH:1'] }
-      it do
-        expect_any_instance_of(described_class).to receive(:hive).with(hash_including(variables: { 'YEAR' => '2015', 'MONTH' => '1'})).once.and_return(mock_success)
-        cli_invocation
-      end
+  context 'with -X YEAR:2015 MONTH:1' do
+    let(:options) { ['-X', 'YEAR:2015', 'MONTH:1'] }
+    it do
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_including(variables: { 'YEAR' => '2015', 'MONTH' => '1'})).once.and_return(mock_success)
+      cli_invocation
     end
   end
 end

--- a/spec/masamune/tasks/postgres_thor_spec.rb
+++ b/spec/masamune/tasks/postgres_thor_spec.rb
@@ -31,10 +31,18 @@ describe Masamune::Tasks::PostgresThor do
     it_behaves_like 'command usage'
   end
 
+  context 'with --file and --initialize' do
+    let(:options) { ['--file=zombo.hql', '--initialize'] }
+    it do
+      expect_any_instance_of(described_class).to receive(:postgres).with(file: instance_of(String)).once.and_return(mock_success)
+      expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(file: 'zombo.hql')).once.and_return(mock_success)
+      cli_invocation
+    end
+  end
+
   context 'with --file' do
     let(:options) { ['--file=zombo.hql'] }
     it do
-      expect_any_instance_of(described_class).to receive(:postgres).with(file: instance_of(String)).once.and_return(mock_success)
       expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(file: 'zombo.hql')).once.and_return(mock_success)
       cli_invocation
     end


### PR DESCRIPTION
Only initialize data stores when '--init' flag is passed.  Saves unnecessary database exist checks and schema loads that only need to be performed once when running parallel tasks.