### PR TITLE
Use SecureRandom.urlsafe_base64

### DIFF
--- a/lib/masamune/filesystem.rb
+++ b/lib/masamune/filesystem.rb
@@ -407,13 +407,13 @@ module Masamune
     end
 
     def mktemp!(path)
-      get_path(path, SecureRandom.base64).tap do |file|
+      get_path(path, SecureRandom.urlsafe_base64).tap do |file|
         touch!(file)
       end
     end
 
     def mktempdir!(path)
-      get_path(path, SecureRandom.base64).tap do |dir|
+      get_path(path, SecureRandom.urlsafe_base64).tap do |dir|
         mkdir!(dir)
       end
     end


### PR DESCRIPTION
Uploaded temporary s3 files are randomly failing on read when `SecureRandom.base64` does not have a URL safe encoding