### PR TITLE
Fix consolidation order

### DIFF
--- a/lib/masamune/transform/consolidate_dimension.rb
+++ b/lib/masamune/transform/consolidate_dimension.rb
@@ -44,8 +44,8 @@ module Masamune::Transform
         define_table(target.stage_table(suffix: 'deduplicated')),
         snapshot_dimension(target.ledger_table, target.stage_table(suffix: 'consolidated_forward'), 'ASC'),
         snapshot_dimension(target.ledger_table, target.stage_table(suffix: 'consolidated_reverse'), 'DESC'),
-        bulk_upsert(target.stage_table(suffix: 'consolidated_forward'), target.stage_table(suffix: 'consolidated')),
         bulk_upsert(target.stage_table(suffix: 'consolidated_reverse'), target.stage_table(suffix: 'consolidated')),
+        bulk_upsert(target.stage_table(suffix: 'consolidated_forward'), target.stage_table(suffix: 'consolidated')),
         deduplicate_dimension(target.stage_table(suffix: 'consolidated'), target.stage_table(suffix: 'deduplicated')),
         bulk_upsert(target.stage_table(suffix: 'deduplicated'), target),
         relabel_dimension(target)

--- a/masamune.gemspec
+++ b/masamune.gemspec
@@ -23,9 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('tilt')
   s.add_dependency('erubis')
   s.add_dependency('parallel')
-  s.add_dependency('pry')
-  # Needed to work around: https://github.com/pry/pry/issues/1217
-  s.add_dependency('rb-readline')
+  s.add_dependency('pry', '>= 0.10.1')
 
   # Development
   s.add_development_dependency('rake', '>= 0.9')

--- a/spec/masamune/transform/consolidate_dimension_spec.rb
+++ b/spec/masamune/transform/consolidate_dimension_spec.rb
@@ -52,8 +52,8 @@ describe Masamune::Transform::ConsolidateDimension do
         transform.define_table(target.stage_table(suffix: 'deduplicated')),
         transform.snapshot_dimension(target.ledger_table, target.stage_table(suffix: 'consolidated_forward'), 'ASC'),
         transform.snapshot_dimension(target.ledger_table, target.stage_table(suffix: 'consolidated_reverse'), 'DESC'),
-        transform.bulk_upsert(target.stage_table(suffix: 'consolidated_forward'), target.stage_table(suffix: 'consolidated')),
         transform.bulk_upsert(target.stage_table(suffix: 'consolidated_reverse'), target.stage_table(suffix: 'consolidated')),
+        transform.bulk_upsert(target.stage_table(suffix: 'consolidated_forward'), target.stage_table(suffix: 'consolidated')),
         transform.deduplicate_dimension(target.stage_table(suffix: 'consolidated'), target.stage_table(suffix: 'deduplicated')),
         transform.bulk_upsert(target.stage_table(suffix: 'deduplicated'), target),
         transform.relabel_dimension(target)


### PR DESCRIPTION
Upsert the reverse consolidated table before the forward consolidated table to ensure that forward consolidations have higher priority