### PR TITLE
Change file locking semantics

### DIFF
--- a/lib/masamune/data_plan/builder.rb
+++ b/lib/masamune/data_plan/builder.rb
@@ -58,9 +58,7 @@ class Masamune::DataPlan::Builder
 
   def thor_command_wrapper
     Proc.new do |engine, rule, _|
-      engine.environment.with_exclusive_lock(rule) do
-        engine.environment.parent.invoke(rule)
-      end
+      engine.environment.parent.invoke(rule)
     end
   end
 end

--- a/lib/masamune/data_plan/engine.rb
+++ b/lib/masamune/data_plan/engine.rb
@@ -141,10 +141,6 @@ class Masamune::DataPlan::Engine
     clear!
   end
 
-  def executing?
-    @current_depth > 0
-  end
-
   def constrain_max_depth(rule)
     @current_depth += 1
     raise "Max depth of #{MAX_DEPTH} exceeded for rule '#{rule}'" if @current_depth > MAX_DEPTH

--- a/lib/masamune/environment.rb
+++ b/lib/masamune/environment.rb
@@ -53,21 +53,29 @@ module Masamune
       @mutex ||= Mutex.new
     end
 
-    def with_exclusive_lock(name, &block)
+    def with_exclusive_lock(name, non_blocking: false, &block)
       raise 'filesystem path :run_dir not defined' unless filesystem.has_path?(:run_dir)
       lock_name = [name, configuration.lock].compact.join(':')
       logger.debug("acquiring lock '#{lock_name}'")
       lock_file = lock_file(lock_name)
-      lock_status = lock_file.flock(File::LOCK_EX | File::LOCK_NB)
+      lock_mode = File::LOCK_EX
+      lock_mode |= File::LOCK_NB if non_blocking
+      lock_status = lock_file.flock(lock_mode)
       if lock_status == 0
         yield if block_given?
       else
-        logger.error "acquire lock attempt failed for '#{lock_name}'"
+        logger.error "acquire lock attempt failed for '#{lock_name}'" unless non_blocking
       end
     ensure
       if lock_file
         logger.debug("releasing lock '#{lock_name}'")
         lock_file.flock(File::LOCK_UN)
+      end
+    end
+
+    def with_process_lock(name)
+      with_exclusive_lock("#{name}_#{Process.pid}", non_blocking: true) do
+        yield
       end
     end
 

--- a/lib/masamune/environment.rb
+++ b/lib/masamune/environment.rb
@@ -53,18 +53,18 @@ module Masamune
       @mutex ||= Mutex.new
     end
 
-    def with_exclusive_lock(name, non_blocking: false, &block)
+    def with_exclusive_lock(name, options = {}, &block)
       raise 'filesystem path :run_dir not defined' unless filesystem.has_path?(:run_dir)
       lock_name = [name, configuration.lock].compact.join(':')
       logger.debug("acquiring lock '#{lock_name}'")
       lock_file = lock_file(lock_name)
       lock_mode = File::LOCK_EX
-      lock_mode |= File::LOCK_NB if non_blocking
+      lock_mode |= File::LOCK_NB if options[:non_blocking]
       lock_status = lock_file.flock(lock_mode)
       if lock_status == 0
         yield if block_given?
       else
-        logger.error "acquire lock attempt failed for '#{lock_name}'" unless non_blocking
+        logger.error "acquire lock attempt failed for '#{lock_name}'" unless options[:non_blocking]
       end
     ensure
       if lock_file

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -160,6 +160,18 @@ module Masamune
           def top_level?
             self.current_command_name == ARGV.first
           end
+
+          def invoke_command(command, *args)
+            environment.with_exclusive_lock(command.name, non_blocking: true) do
+              super
+            end
+          end
+
+          def invoke(name = nil, *args)
+            environment.with_exclusive_lock(name, non_blocking: top_level?) do
+              super
+            end
+          end
         end
 
         private


### PR DESCRIPTION
- Set exclusive non blocking lock for `top_level` command. Goal is to
  force rival top-level commands to fail fast.

- Set exclusive blocking lock for child commands. Goal is to allow
  tasks that share downstream dependencies to issue a single command to
  rebuild downstream dependency and collectively wait for result
  upstream.

- Set exclusive non blocking lock for per process data plan configuration. A
  process only needs to initialize and begin executing data plan once.