### PR TITLE
Fix stage table lock on `ADD CONSTRAINT .. FOREIGN_KEY`

### DIFF
--- a/lib/masamune/schema/fact.rb
+++ b/lib/masamune/schema/fact.rb
@@ -63,12 +63,13 @@ module Masamune::Schema
       columns.values.detect { |column| column.id == :time_key }
     end
 
-    def stage_table(*a)
-      super.tap do |stage|
-        stage.id    = @id
-        stage.store = store
-        stage.range = range
-        stage.grain = grain
+    def stage_table(options = {})
+      super(options).tap do |stage|
+        stage.id      = @id
+        stage.suffix  = options[:suffix]
+        stage.store   = store
+        stage.range   = range
+        stage.grain   = grain
         stage.columns.each do |_, column|
           column.unique = false
         end

--- a/lib/masamune/transform/rollup_fact.psql.erb
+++ b/lib/masamune/transform/rollup_fact.psql.erb
@@ -20,9 +20,7 @@
 --  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 --  THE SOFTWARE.
 
-<%- target_stage = target.stage_table %>
-
-BEGIN;
+<%- target_stage = target.stage_table(suffix: Process.pid) %>
 
 DROP TABLE IF EXISTS <%= target_stage.name %> CASCADE;
 CREATE TABLE IF NOT EXISTS <%= target_stage.name %> (LIKE <%= target.parent.name %> INCLUDING ALL);
@@ -56,8 +54,6 @@ GROUP BY
 <%- index_name = "#{target_stage.name}_#{column_names.join('_')}_index" -%>
 CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target_stage.name %> (<%= column_names.join(', ') %>);
 <%- end -%>
-
-COMMIT;
 
 BEGIN;
 

--- a/lib/masamune/transform/stage_fact.psql.erb
+++ b/lib/masamune/transform/stage_fact.psql.erb
@@ -21,9 +21,7 @@
 --  THE SOFTWARE.
 
 <%- target_partition = target.partition_table(date) %>
-<%- target_stage = target_partition.stage_table %>
-
-BEGIN;
+<%- target_stage = target_partition.stage_table(suffix: Process.pid) %>
 
 DROP TABLE IF EXISTS <%= target_stage.name %> CASCADE;
 CREATE TABLE IF NOT EXISTS <%= target_stage.name %> (LIKE <%= target.name %> INCLUDING ALL);
@@ -55,8 +53,6 @@ ON
 <%- index_name = "#{target_stage.name}_#{column_names.join('_')}_index" -%>
 CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target_stage.name %> (<%= column_names.join(', ') %>);
 <%- end -%>
-
-COMMIT;
 
 BEGIN;
 

--- a/spec/masamune/schema/fact_spec.rb
+++ b/spec/masamune/schema/fact_spec.rb
@@ -68,6 +68,16 @@ describe Masamune::Schema::Fact do
       it { expect(stage_table.store.id).to eq(store.id) }
       it { expect(stage_table.name).to eq('visits_fact_y2015m01_stage') }
       it { expect(stage_table.range.start_date).to eq(date.utc.to_date) }
+
+      context 'with optional suffix' do
+        subject(:stage_table) { partition_table.stage_table(suffix: 'tmp') }
+
+        it 'should append suffix to id' do
+          expect(stage_table.store.id).to eq(store.id)
+          expect(stage_table.name).to eq('visits_fact_y2015m01_stage_tmp')
+          expect(stage_table.range.start_date).to eq(date.utc.to_date)
+        end
+      end
     end
   end
 

--- a/spec/masamune/transform/rollup_fact_spec.rb
+++ b/spec/masamune/transform/rollup_fact_spec.rb
@@ -24,6 +24,8 @@ require 'spec_helper'
 
 describe Masamune::Transform::RollupFact do
   before do
+    allow(Process).to receive(:pid).and_return('PID')
+
     catalog.schema :postgres do
       dimension 'cluster', type: :mini do
         column 'id', type: :sequence, surrogate_key: true, auto: true
@@ -90,21 +92,19 @@ describe Masamune::Transform::RollupFact do
 
     it 'should eq render rollup_fact template' do
       is_expected.to eq <<-EOS.strip_heredoc
-        BEGIN;
+        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage_PID CASCADE;
+        CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08_stage_PID (LIKE visits_hourly_fact INCLUDING ALL);
 
-        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage CASCADE;
-        CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08_stage (LIKE visits_hourly_fact INCLUDING ALL);
-
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id);
 
         INSERT INTO
-          visits_hourly_fact_y2014m08_stage (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
+          visits_hourly_fact_y2014m08_stage_PID (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
         SELECT
           (SELECT id FROM date_dimension d WHERE d.date_epoch = date_dimension.date_epoch ORDER BY d.date_id LIMIT 1),
           visits_transaction_fact_y2014m08.tenant_dimension_id,
@@ -128,20 +128,18 @@ describe Masamune::Transform::RollupFact do
           (visits_transaction_fact_y2014m08.time_key - (visits_transaction_fact_y2014m08.time_key % 3600))
         ;
 
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_cluster_type_id_index ON visits_hourly_fact_y2014m08_stage (cluster_type_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_date_dimension_id_index ON visits_hourly_fact_y2014m08_stage (date_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_tenant_dimension_id_index ON visits_hourly_fact_y2014m08_stage (tenant_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_user_dimension_id_index ON visits_hourly_fact_y2014m08_stage (user_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_user_agent_type_id_index ON visits_hourly_fact_y2014m08_stage (user_agent_type_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_feature_type_id_index ON visits_hourly_fact_y2014m08_stage (feature_type_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_time_key_index ON visits_hourly_fact_y2014m08_stage (time_key);
-
-        COMMIT;
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_cluster_type_id_index ON visits_hourly_fact_y2014m08_stage_PID (cluster_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_date_dimension_id_index ON visits_hourly_fact_y2014m08_stage_PID (date_dimension_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_tenant_dimension_id_index ON visits_hourly_fact_y2014m08_stage_PID (tenant_dimension_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_user_dimension_id_index ON visits_hourly_fact_y2014m08_stage_PID (user_dimension_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_user_agent_type_id_index ON visits_hourly_fact_y2014m08_stage_PID (user_agent_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_feature_type_id_index ON visits_hourly_fact_y2014m08_stage_PID (feature_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_time_key_index ON visits_hourly_fact_y2014m08_stage_PID (time_key);
 
         BEGIN;
 
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08;
-        ALTER TABLE visits_hourly_fact_y2014m08_stage RENAME TO visits_hourly_fact_y2014m08;
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID RENAME TO visits_hourly_fact_y2014m08;
 
         ALTER TABLE visits_hourly_fact_y2014m08 INHERIT visits_hourly_fact;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600) NOT VALID;
@@ -152,13 +150,13 @@ describe Masamune::Transform::RollupFact do
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID;
 
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_cluster_type_id_index RENAME TO visits_hourly_fact_y2014m08_cluster_type_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_date_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_date_dimension_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_tenant_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_tenant_dimension_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_user_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_user_dimension_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_user_agent_type_id_index RENAME TO visits_hourly_fact_y2014m08_user_agent_type_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_feature_type_id_index RENAME TO visits_hourly_fact_y2014m08_feature_type_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_time_key_index RENAME TO visits_hourly_fact_y2014m08_time_key_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_cluster_type_id_index RENAME TO visits_hourly_fact_y2014m08_cluster_type_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_date_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_date_dimension_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_tenant_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_tenant_dimension_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_user_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_user_dimension_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_user_agent_type_id_index RENAME TO visits_hourly_fact_y2014m08_user_agent_type_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_feature_type_id_index RENAME TO visits_hourly_fact_y2014m08_feature_type_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_time_key_index RENAME TO visits_hourly_fact_y2014m08_time_key_index;
 
         COMMIT;
       EOS
@@ -174,21 +172,19 @@ describe Masamune::Transform::RollupFact do
 
     it 'should eq render rollup_fact template' do
       is_expected.to eq <<-EOS.strip_heredoc
-        BEGIN;
+        DROP TABLE IF EXISTS visits_daily_fact_y2014m08_stage_PID CASCADE;
+        CREATE TABLE IF NOT EXISTS visits_daily_fact_y2014m08_stage_PID (LIKE visits_daily_fact INCLUDING ALL);
 
-        DROP TABLE IF EXISTS visits_daily_fact_y2014m08_stage CASCADE;
-        CREATE TABLE IF NOT EXISTS visits_daily_fact_y2014m08_stage (LIKE visits_daily_fact INCLUDING ALL);
-
-        ALTER TABLE visits_daily_fact_y2014m08_stage ADD CONSTRAINT visits_daily_fact_y2014m08_stage_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
-        ALTER TABLE visits_daily_fact_y2014m08_stage ADD CONSTRAINT visits_daily_fact_y2014m08_stage_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
-        ALTER TABLE visits_daily_fact_y2014m08_stage ADD CONSTRAINT visits_daily_fact_y2014m08_stage_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id);
-        ALTER TABLE visits_daily_fact_y2014m08_stage ADD CONSTRAINT visits_daily_fact_y2014m08_stage_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id);
-        ALTER TABLE visits_daily_fact_y2014m08_stage ADD CONSTRAINT visits_daily_fact_y2014m08_stage_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id);
-        ALTER TABLE visits_daily_fact_y2014m08_stage ADD CONSTRAINT visits_daily_fact_y2014m08_stage_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id);
-        ALTER TABLE visits_daily_fact_y2014m08_stage ADD CONSTRAINT visits_daily_fact_y2014m08_stage_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id);
+        ALTER TABLE visits_daily_fact_y2014m08_stage_PID ADD CONSTRAINT visits_daily_fact_y2014m08_stage_PID_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
+        ALTER TABLE visits_daily_fact_y2014m08_stage_PID ADD CONSTRAINT visits_daily_fact_y2014m08_stage_PID_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
+        ALTER TABLE visits_daily_fact_y2014m08_stage_PID ADD CONSTRAINT visits_daily_fact_y2014m08_stage_PID_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id);
+        ALTER TABLE visits_daily_fact_y2014m08_stage_PID ADD CONSTRAINT visits_daily_fact_y2014m08_stage_PID_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id);
+        ALTER TABLE visits_daily_fact_y2014m08_stage_PID ADD CONSTRAINT visits_daily_fact_y2014m08_stage_PID_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id);
+        ALTER TABLE visits_daily_fact_y2014m08_stage_PID ADD CONSTRAINT visits_daily_fact_y2014m08_stage_PID_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id);
+        ALTER TABLE visits_daily_fact_y2014m08_stage_PID ADD CONSTRAINT visits_daily_fact_y2014m08_stage_PID_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id);
 
         INSERT INTO
-          visits_daily_fact_y2014m08_stage (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
+          visits_daily_fact_y2014m08_stage_PID (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
         SELECT
           (SELECT id FROM date_dimension d WHERE d.date_epoch = date_dimension.date_epoch ORDER BY d.date_id LIMIT 1),
           visits_hourly_fact_y2014m08.tenant_dimension_id,
@@ -211,20 +207,18 @@ describe Masamune::Transform::RollupFact do
           visits_hourly_fact_y2014m08.feature_type_id
         ;
 
-        CREATE INDEX visits_daily_fact_y2014m08_stage_cluster_type_id_index ON visits_daily_fact_y2014m08_stage (cluster_type_id);
-        CREATE INDEX visits_daily_fact_y2014m08_stage_date_dimension_id_index ON visits_daily_fact_y2014m08_stage (date_dimension_id);
-        CREATE INDEX visits_daily_fact_y2014m08_stage_tenant_dimension_id_index ON visits_daily_fact_y2014m08_stage (tenant_dimension_id);
-        CREATE INDEX visits_daily_fact_y2014m08_stage_user_dimension_id_index ON visits_daily_fact_y2014m08_stage (user_dimension_id);
-        CREATE INDEX visits_daily_fact_y2014m08_stage_user_agent_type_id_index ON visits_daily_fact_y2014m08_stage (user_agent_type_id);
-        CREATE INDEX visits_daily_fact_y2014m08_stage_feature_type_id_index ON visits_daily_fact_y2014m08_stage (feature_type_id);
-        CREATE INDEX visits_daily_fact_y2014m08_stage_time_key_index ON visits_daily_fact_y2014m08_stage (time_key);
-
-        COMMIT;
+        CREATE INDEX visits_daily_fact_y2014m08_stage_PID_cluster_type_id_index ON visits_daily_fact_y2014m08_stage_PID (cluster_type_id);
+        CREATE INDEX visits_daily_fact_y2014m08_stage_PID_date_dimension_id_index ON visits_daily_fact_y2014m08_stage_PID (date_dimension_id);
+        CREATE INDEX visits_daily_fact_y2014m08_stage_PID_tenant_dimension_id_index ON visits_daily_fact_y2014m08_stage_PID (tenant_dimension_id);
+        CREATE INDEX visits_daily_fact_y2014m08_stage_PID_user_dimension_id_index ON visits_daily_fact_y2014m08_stage_PID (user_dimension_id);
+        CREATE INDEX visits_daily_fact_y2014m08_stage_PID_user_agent_type_id_index ON visits_daily_fact_y2014m08_stage_PID (user_agent_type_id);
+        CREATE INDEX visits_daily_fact_y2014m08_stage_PID_feature_type_id_index ON visits_daily_fact_y2014m08_stage_PID (feature_type_id);
+        CREATE INDEX visits_daily_fact_y2014m08_stage_PID_time_key_index ON visits_daily_fact_y2014m08_stage_PID (time_key);
 
         BEGIN;
 
         DROP TABLE IF EXISTS visits_daily_fact_y2014m08;
-        ALTER TABLE visits_daily_fact_y2014m08_stage RENAME TO visits_daily_fact_y2014m08;
+        ALTER TABLE visits_daily_fact_y2014m08_stage_PID RENAME TO visits_daily_fact_y2014m08;
 
         ALTER TABLE visits_daily_fact_y2014m08 INHERIT visits_daily_fact;
         ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600) NOT VALID;
@@ -235,13 +229,13 @@ describe Masamune::Transform::RollupFact do
         ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID;
         ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID;
 
-        ALTER INDEX visits_daily_fact_y2014m08_stage_cluster_type_id_index RENAME TO visits_daily_fact_y2014m08_cluster_type_id_index;
-        ALTER INDEX visits_daily_fact_y2014m08_stage_date_dimension_id_index RENAME TO visits_daily_fact_y2014m08_date_dimension_id_index;
-        ALTER INDEX visits_daily_fact_y2014m08_stage_tenant_dimension_id_index RENAME TO visits_daily_fact_y2014m08_tenant_dimension_id_index;
-        ALTER INDEX visits_daily_fact_y2014m08_stage_user_dimension_id_index RENAME TO visits_daily_fact_y2014m08_user_dimension_id_index;
-        ALTER INDEX visits_daily_fact_y2014m08_stage_user_agent_type_id_index RENAME TO visits_daily_fact_y2014m08_user_agent_type_id_index;
-        ALTER INDEX visits_daily_fact_y2014m08_stage_feature_type_id_index RENAME TO visits_daily_fact_y2014m08_feature_type_id_index;
-        ALTER INDEX visits_daily_fact_y2014m08_stage_time_key_index RENAME TO visits_daily_fact_y2014m08_time_key_index;
+        ALTER INDEX visits_daily_fact_y2014m08_stage_PID_cluster_type_id_index RENAME TO visits_daily_fact_y2014m08_cluster_type_id_index;
+        ALTER INDEX visits_daily_fact_y2014m08_stage_PID_date_dimension_id_index RENAME TO visits_daily_fact_y2014m08_date_dimension_id_index;
+        ALTER INDEX visits_daily_fact_y2014m08_stage_PID_tenant_dimension_id_index RENAME TO visits_daily_fact_y2014m08_tenant_dimension_id_index;
+        ALTER INDEX visits_daily_fact_y2014m08_stage_PID_user_dimension_id_index RENAME TO visits_daily_fact_y2014m08_user_dimension_id_index;
+        ALTER INDEX visits_daily_fact_y2014m08_stage_PID_user_agent_type_id_index RENAME TO visits_daily_fact_y2014m08_user_agent_type_id_index;
+        ALTER INDEX visits_daily_fact_y2014m08_stage_PID_feature_type_id_index RENAME TO visits_daily_fact_y2014m08_feature_type_id_index;
+        ALTER INDEX visits_daily_fact_y2014m08_stage_PID_time_key_index RENAME TO visits_daily_fact_y2014m08_time_key_index;
 
         COMMIT;
       EOS
@@ -257,21 +251,19 @@ describe Masamune::Transform::RollupFact do
 
     it 'should eq render rollup_fact template' do
       is_expected.to eq <<-EOS.strip_heredoc
-        BEGIN;
+        DROP TABLE IF EXISTS visits_monthly_fact_y2014m08_stage_PID CASCADE;
+        CREATE TABLE IF NOT EXISTS visits_monthly_fact_y2014m08_stage_PID (LIKE visits_monthly_fact INCLUDING ALL);
 
-        DROP TABLE IF EXISTS visits_monthly_fact_y2014m08_stage CASCADE;
-        CREATE TABLE IF NOT EXISTS visits_monthly_fact_y2014m08_stage (LIKE visits_monthly_fact INCLUDING ALL);
-
-        ALTER TABLE visits_monthly_fact_y2014m08_stage ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
-        ALTER TABLE visits_monthly_fact_y2014m08_stage ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
-        ALTER TABLE visits_monthly_fact_y2014m08_stage ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id);
-        ALTER TABLE visits_monthly_fact_y2014m08_stage ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id);
-        ALTER TABLE visits_monthly_fact_y2014m08_stage ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id);
-        ALTER TABLE visits_monthly_fact_y2014m08_stage ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id);
-        ALTER TABLE visits_monthly_fact_y2014m08_stage ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id);
+        ALTER TABLE visits_monthly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_PID_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
+        ALTER TABLE visits_monthly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_PID_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
+        ALTER TABLE visits_monthly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_PID_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id);
+        ALTER TABLE visits_monthly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_PID_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id);
+        ALTER TABLE visits_monthly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_PID_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id);
+        ALTER TABLE visits_monthly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_PID_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id);
+        ALTER TABLE visits_monthly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_monthly_fact_y2014m08_stage_PID_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id);
 
         INSERT INTO
-          visits_monthly_fact_y2014m08_stage (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
+          visits_monthly_fact_y2014m08_stage_PID (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
         SELECT
           (SELECT id FROM date_dimension d WHERE d.month_epoch = date_dimension.month_epoch ORDER BY d.date_id LIMIT 1),
           visits_daily_fact_y2014m08.tenant_dimension_id,
@@ -294,20 +286,18 @@ describe Masamune::Transform::RollupFact do
           visits_daily_fact_y2014m08.feature_type_id
         ;
 
-        CREATE INDEX visits_monthly_fact_y2014m08_stage_cluster_type_id_index ON visits_monthly_fact_y2014m08_stage (cluster_type_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_stage_date_dimension_id_index ON visits_monthly_fact_y2014m08_stage (date_dimension_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_stage_tenant_dimension_id_index ON visits_monthly_fact_y2014m08_stage (tenant_dimension_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_stage_user_dimension_id_index ON visits_monthly_fact_y2014m08_stage (user_dimension_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_stage_user_agent_type_id_index ON visits_monthly_fact_y2014m08_stage (user_agent_type_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_stage_feature_type_id_index ON visits_monthly_fact_y2014m08_stage (feature_type_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_stage_time_key_index ON visits_monthly_fact_y2014m08_stage (time_key);
-
-        COMMIT;
+        CREATE INDEX visits_monthly_fact_y2014m08_stage_PID_cluster_type_id_index ON visits_monthly_fact_y2014m08_stage_PID (cluster_type_id);
+        CREATE INDEX visits_monthly_fact_y2014m08_stage_PID_date_dimension_id_index ON visits_monthly_fact_y2014m08_stage_PID (date_dimension_id);
+        CREATE INDEX visits_monthly_fact_y2014m08_stage_PID_tenant_dimension_id_index ON visits_monthly_fact_y2014m08_stage_PID (tenant_dimension_id);
+        CREATE INDEX visits_monthly_fact_y2014m08_stage_PID_user_dimension_id_index ON visits_monthly_fact_y2014m08_stage_PID (user_dimension_id);
+        CREATE INDEX visits_monthly_fact_y2014m08_stage_PID_user_agent_type_id_index ON visits_monthly_fact_y2014m08_stage_PID (user_agent_type_id);
+        CREATE INDEX visits_monthly_fact_y2014m08_stage_PID_feature_type_id_index ON visits_monthly_fact_y2014m08_stage_PID (feature_type_id);
+        CREATE INDEX visits_monthly_fact_y2014m08_stage_PID_time_key_index ON visits_monthly_fact_y2014m08_stage_PID (time_key);
 
         BEGIN;
 
         DROP TABLE IF EXISTS visits_monthly_fact_y2014m08;
-        ALTER TABLE visits_monthly_fact_y2014m08_stage RENAME TO visits_monthly_fact_y2014m08;
+        ALTER TABLE visits_monthly_fact_y2014m08_stage_PID RENAME TO visits_monthly_fact_y2014m08;
 
         ALTER TABLE visits_monthly_fact_y2014m08 INHERIT visits_monthly_fact;
         ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600) NOT VALID;
@@ -318,13 +308,13 @@ describe Masamune::Transform::RollupFact do
         ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID;
         ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID;
 
-        ALTER INDEX visits_monthly_fact_y2014m08_stage_cluster_type_id_index RENAME TO visits_monthly_fact_y2014m08_cluster_type_id_index;
-        ALTER INDEX visits_monthly_fact_y2014m08_stage_date_dimension_id_index RENAME TO visits_monthly_fact_y2014m08_date_dimension_id_index;
-        ALTER INDEX visits_monthly_fact_y2014m08_stage_tenant_dimension_id_index RENAME TO visits_monthly_fact_y2014m08_tenant_dimension_id_index;
-        ALTER INDEX visits_monthly_fact_y2014m08_stage_user_dimension_id_index RENAME TO visits_monthly_fact_y2014m08_user_dimension_id_index;
-        ALTER INDEX visits_monthly_fact_y2014m08_stage_user_agent_type_id_index RENAME TO visits_monthly_fact_y2014m08_user_agent_type_id_index;
-        ALTER INDEX visits_monthly_fact_y2014m08_stage_feature_type_id_index RENAME TO visits_monthly_fact_y2014m08_feature_type_id_index;
-        ALTER INDEX visits_monthly_fact_y2014m08_stage_time_key_index RENAME TO visits_monthly_fact_y2014m08_time_key_index;
+        ALTER INDEX visits_monthly_fact_y2014m08_stage_PID_cluster_type_id_index RENAME TO visits_monthly_fact_y2014m08_cluster_type_id_index;
+        ALTER INDEX visits_monthly_fact_y2014m08_stage_PID_date_dimension_id_index RENAME TO visits_monthly_fact_y2014m08_date_dimension_id_index;
+        ALTER INDEX visits_monthly_fact_y2014m08_stage_PID_tenant_dimension_id_index RENAME TO visits_monthly_fact_y2014m08_tenant_dimension_id_index;
+        ALTER INDEX visits_monthly_fact_y2014m08_stage_PID_user_dimension_id_index RENAME TO visits_monthly_fact_y2014m08_user_dimension_id_index;
+        ALTER INDEX visits_monthly_fact_y2014m08_stage_PID_user_agent_type_id_index RENAME TO visits_monthly_fact_y2014m08_user_agent_type_id_index;
+        ALTER INDEX visits_monthly_fact_y2014m08_stage_PID_feature_type_id_index RENAME TO visits_monthly_fact_y2014m08_feature_type_id_index;
+        ALTER INDEX visits_monthly_fact_y2014m08_stage_PID_time_key_index RENAME TO visits_monthly_fact_y2014m08_time_key_index;
 
         COMMIT;
       EOS

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -24,6 +24,8 @@ require 'spec_helper'
 
 describe Masamune::Transform::StageFact do
   before do
+    allow(Process).to receive(:pid).and_return('PID')
+
     catalog.schema :postgres do
       dimension 'cluster', type: :mini do
         column 'id', type: :sequence, surrogate_key: true, auto: true
@@ -100,22 +102,20 @@ describe Masamune::Transform::StageFact do
 
     it 'should eq render stage_fact template' do
       is_expected.to eq <<-EOS.strip_heredoc
-        BEGIN;
+        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage_PID CASCADE;
+        CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08_stage_PID (LIKE visits_hourly_fact INCLUDING ALL);
 
-        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage CASCADE;
-        CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08_stage (LIKE visits_hourly_fact INCLUDING ALL);
-
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_group_dimension_id_fkey FOREIGN KEY (group_dimension_id) REFERENCES group_dimension(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id);
-        ALTER TABLE visits_hourly_fact_y2014m08_stage ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_group_dimension_id_fkey FOREIGN KEY (group_dimension_id) REFERENCES group_dimension(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id);
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID ADD CONSTRAINT visits_hourly_fact_y2014m08_stage_PID_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id);
 
         INSERT INTO
-          visits_hourly_fact_y2014m08_stage (date_dimension_id, tenant_dimension_id, user_dimension_id, group_dimension_id, user_agent_type_id, feature_type_id, session_type_id, total, time_key)
+          visits_hourly_fact_y2014m08_stage_PID (date_dimension_id, tenant_dimension_id, user_dimension_id, group_dimension_id, user_agent_type_id, feature_type_id, session_type_id, total, time_key)
         SELECT
           date_dimension.id,
           tenant_dimension.id,
@@ -160,22 +160,20 @@ describe Masamune::Transform::StageFact do
           feature_type.name = visits_hourly_file_fact_stage.feature_type_name
         ;
 
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_cluster_type_id_index ON visits_hourly_fact_y2014m08_stage (cluster_type_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_date_dimension_id_index ON visits_hourly_fact_y2014m08_stage (date_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_tenant_dimension_id_index ON visits_hourly_fact_y2014m08_stage (tenant_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_user_dimension_id_index ON visits_hourly_fact_y2014m08_stage (user_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_group_dimension_id_index ON visits_hourly_fact_y2014m08_stage (group_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_user_agent_type_id_index ON visits_hourly_fact_y2014m08_stage (user_agent_type_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_feature_type_id_index ON visits_hourly_fact_y2014m08_stage (feature_type_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_session_type_id_index ON visits_hourly_fact_y2014m08_stage (session_type_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_stage_time_key_index ON visits_hourly_fact_y2014m08_stage (time_key);
-
-        COMMIT;
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_cluster_type_id_index ON visits_hourly_fact_y2014m08_stage_PID (cluster_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_date_dimension_id_index ON visits_hourly_fact_y2014m08_stage_PID (date_dimension_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_tenant_dimension_id_index ON visits_hourly_fact_y2014m08_stage_PID (tenant_dimension_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_user_dimension_id_index ON visits_hourly_fact_y2014m08_stage_PID (user_dimension_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_group_dimension_id_index ON visits_hourly_fact_y2014m08_stage_PID (group_dimension_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_user_agent_type_id_index ON visits_hourly_fact_y2014m08_stage_PID (user_agent_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_feature_type_id_index ON visits_hourly_fact_y2014m08_stage_PID (feature_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_session_type_id_index ON visits_hourly_fact_y2014m08_stage_PID (session_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_stage_PID_time_key_index ON visits_hourly_fact_y2014m08_stage_PID (time_key);
 
         BEGIN;
 
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08;
-        ALTER TABLE visits_hourly_fact_y2014m08_stage RENAME TO visits_hourly_fact_y2014m08;
+        ALTER TABLE visits_hourly_fact_y2014m08_stage_PID RENAME TO visits_hourly_fact_y2014m08;
 
         ALTER TABLE visits_hourly_fact_y2014m08 INHERIT visits_hourly_fact;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600) NOT VALID;
@@ -187,15 +185,15 @@ describe Masamune::Transform::StageFact do
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID;
 
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_cluster_type_id_index RENAME TO visits_hourly_fact_y2014m08_cluster_type_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_date_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_date_dimension_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_tenant_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_tenant_dimension_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_user_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_user_dimension_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_group_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_group_dimension_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_user_agent_type_id_index RENAME TO visits_hourly_fact_y2014m08_user_agent_type_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_feature_type_id_index RENAME TO visits_hourly_fact_y2014m08_feature_type_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_session_type_id_index RENAME TO visits_hourly_fact_y2014m08_session_type_id_index;
-        ALTER INDEX visits_hourly_fact_y2014m08_stage_time_key_index RENAME TO visits_hourly_fact_y2014m08_time_key_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_cluster_type_id_index RENAME TO visits_hourly_fact_y2014m08_cluster_type_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_date_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_date_dimension_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_tenant_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_tenant_dimension_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_user_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_user_dimension_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_group_dimension_id_index RENAME TO visits_hourly_fact_y2014m08_group_dimension_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_user_agent_type_id_index RENAME TO visits_hourly_fact_y2014m08_user_agent_type_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_feature_type_id_index RENAME TO visits_hourly_fact_y2014m08_feature_type_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_session_type_id_index RENAME TO visits_hourly_fact_y2014m08_session_type_id_index;
+        ALTER INDEX visits_hourly_fact_y2014m08_stage_PID_time_key_index RENAME TO visits_hourly_fact_y2014m08_time_key_index;
 
         COMMIT;
       EOS


### PR DESCRIPTION
I noticed that staging fact table data was locking up. After some investigation and reading- it seems that `ADD CONSTRAINT .. FOREIGN_KEY` without `NOT VALID` in a transaction is a bad idea, since even a read on the foreign table locks the transaction up. Since the stage tables are no longer transactionally created, I appended the `Process.pid` just in case a job gets past file locks for tasks.  The only risk with creating these "temporary" `Process.pid` tables is that they will remain orphaned if a job crashes.