### PR TITLE
Fix lock semantics

### DIFF
--- a/lib/masamune/environment.rb
+++ b/lib/masamune/environment.rb
@@ -67,7 +67,7 @@ module Masamune
         logger.error "acquire lock attempt failed for '#{lock_name}'" unless options[:non_blocking]
       end
     ensure
-      if lock_file
+      if lock_file && lock_status == 0
         logger.debug("releasing lock '#{lock_name}'")
         lock_file.flock(File::LOCK_UN)
       end

--- a/lib/masamune/environment.rb
+++ b/lib/masamune/environment.rb
@@ -53,18 +53,18 @@ module Masamune
       @mutex ||= Mutex.new
     end
 
-    def with_exclusive_lock(name, options = {}, &block)
+    def with_exclusive_lock(name)
       raise 'filesystem path :run_dir not defined' unless filesystem.has_path?(:run_dir)
       lock_name = [name, configuration.lock].compact.join(':')
       logger.debug("acquiring lock '#{lock_name}'")
       lock_file = lock_file(lock_name)
       lock_mode = File::LOCK_EX
-      lock_mode |= File::LOCK_NB if options[:non_blocking]
+      lock_mode |= File::LOCK_NB
       lock_status = lock_file.flock(lock_mode)
       if lock_status == 0
         yield if block_given?
       else
-        logger.error "acquire lock attempt failed for '#{lock_name}'" unless options[:non_blocking]
+        logger.error "acquire lock attempt failed for '#{lock_name}'"
       end
     ensure
       if lock_file && lock_status == 0
@@ -74,7 +74,7 @@ module Masamune
     end
 
     def with_process_lock(name)
-      with_exclusive_lock("#{name}_#{Process.pid}", non_blocking: true) do
+      with_exclusive_lock("#{name}_#{Process.pid}") do
         yield
       end
     end

--- a/lib/masamune/tasks/elastic_mapreduce_thor.rb
+++ b/lib/masamune/tasks/elastic_mapreduce_thor.rb
@@ -31,6 +31,7 @@ module Masamune::Tasks
     # FIXME need to add an unnecessary namespace until this issue is fixed:
     # https://github.com/wycats/thor/pull/247
     namespace :elastic_mapreduce
+    skip_lock!
 
     desc 'elastic_mapreduce', 'Launch an ElasticMapReduce ssh session'
     class_option :template, :type => :string, :aliases => '-t', :desc => 'Execute named template command'

--- a/lib/masamune/tasks/hive_thor.rb
+++ b/lib/masamune/tasks/hive_thor.rb
@@ -32,6 +32,7 @@ module Masamune::Tasks
     # FIXME need to add an unnecessary namespace until this issue is fixed:
     # https://github.com/wycats/thor/pull/247
     namespace :hive
+    skip_lock!
 
     desc 'hive', 'Launch a Hive session'
     method_option :file, :aliases => '-f', :desc => 'SQL from files'

--- a/lib/masamune/tasks/postgres_thor.rb
+++ b/lib/masamune/tasks/postgres_thor.rb
@@ -31,6 +31,7 @@ module Masamune::Tasks
     # FIXME need to add an unnecessary namespace until this issue is fixed:
     # https://github.com/wycats/thor/pull/247
     namespace :postgres
+    skip_lock!
 
     desc 'psql', 'Launch a Postgres session'
     method_option :file, :aliases => '-f', :desc => 'SQL from files'

--- a/lib/masamune/tasks/shell_thor.rb
+++ b/lib/masamune/tasks/shell_thor.rb
@@ -33,6 +33,7 @@ module Masamune::Tasks
     # FIXME need to add an unnecessary namespace until this issue is fixed:
     # https://github.com/wycats/thor/pull/247
     namespace :shell
+    skip_lock!
 
     desc 'shell', 'Launch an interactive shell'
     method_option :dump, :type => :boolean, :desc => 'Dump SQL schema', :default => false

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -103,11 +103,11 @@ module Masamune
         class_option :lock, :desc => 'Optional job lock name', :type => :string
         class_option :initialize, :aliases => '--init', :desc => 'Initialize configured data stores', :type => :boolean, :default => false
         class_option :'--', :desc => 'Extra pass through arguments'
-        def initialize(_args=[], _options={}, _config={})
+        def initialize(_args = [], _options = {}, _config = {})
           self.environment.parent = self
           self.filesystem.environment = self
           self.current_namespace = self.class.namespace unless self.class.namespace == 'masamune'
-          self.current_task_name = _config[:current_command].name
+          self.current_task_name = _config[:current_command].try(:name)
           self.current_command_name = current_namespace ? current_namespace + ':' + current_task_name : current_task_name
           self.class.instance = self
 
@@ -163,17 +163,23 @@ module Masamune
 
           def invoke_command(command, *args)
             return super if self.class.skip_lock?
-            lock_name = "#{current_namespace}:#{command.name}".gsub('_task', '') + '_command'
+            lock_name = qualify_task_name(command.name) + '_command'
             environment.with_exclusive_lock(lock_name, non_blocking: true) do
               super
             end
           end
 
           def invoke(name = nil, *args)
-            lock_name = name.gsub('_task', '')
+            lock_name = qualify_task_name(name) + '_task'
             environment.with_exclusive_lock(lock_name, non_blocking: false) do
               super
             end
+          end
+
+          def qualify_task_name(task_name)
+            task, namespace = *task_name.split(':').reverse
+            namespace ||= current_namespace
+            "#{namespace}:#{task.gsub(/_task\Z/, '')}"
           end
 
           class << self

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -157,18 +157,16 @@ module Masamune
             environment.configuration.params[key]
           end
 
-          def top_level?
-            self.current_command_name == ARGV.first
-          end
-
           def invoke_command(command, *args)
-            environment.with_exclusive_lock(command.name, non_blocking: true) do
+            lock_name = "#{current_namespace}:#{command.name}".gsub('_task', '') + '_command'
+            environment.with_exclusive_lock(lock_name, non_blocking: true) do
               super
             end
           end
 
           def invoke(name = nil, *args)
-            environment.with_exclusive_lock(name, non_blocking: top_level?) do
+            lock_name = name.gsub('_task', '')
+            environment.with_exclusive_lock(lock_name, non_blocking: false) do
               super
             end
           end

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -158,6 +158,7 @@ module Masamune
           end
 
           def invoke_command(command, *args)
+            return super if self.class.skip_lock?
             lock_name = "#{current_namespace}:#{command.name}".gsub('_task', '') + '_command'
             environment.with_exclusive_lock(lock_name, non_blocking: true) do
               super
@@ -168,6 +169,16 @@ module Masamune
             lock_name = name.gsub('_task', '')
             environment.with_exclusive_lock(lock_name, non_blocking: false) do
               super
+            end
+          end
+
+          class << self
+            def skip_lock!
+              @skip_lock = true
+            end
+
+            def skip_lock?
+              @skip_lock
             end
           end
         end

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -157,6 +157,10 @@ module Masamune
             environment.configuration.params[key]
           end
 
+          def top_level?
+            self.current_command_name == ARGV.first
+          end
+
           def invoke_command(command, *args)
             return super if self.class.skip_lock?
             lock_name = "#{current_namespace}:#{command.name}".gsub('_task', '') + '_command'

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -164,14 +164,14 @@ module Masamune
           def invoke_command(command, *args)
             return super if self.class.skip_lock?
             lock_name = qualify_task_name(command.name) + '_command'
-            environment.with_exclusive_lock(lock_name, non_blocking: true) do
+            environment.with_exclusive_lock(lock_name) do
               super
             end
           end
 
           def invoke(name = nil, *args)
             lock_name = qualify_task_name(name) + '_task'
-            environment.with_exclusive_lock(lock_name, non_blocking: false) do
+            environment.with_exclusive_lock(lock_name) do
               super
             end
           end

--- a/spec/masamune/environment_spec.rb
+++ b/spec/masamune/environment_spec.rb
@@ -56,7 +56,7 @@ describe Masamune::Environment do
       before do
         instance.filesystem.add_path(:run_dir, run_dir)
         expect(instance.logger).to receive(:error).with(/acquire lock attempt failed for 'some_lock'/)
-        expect_any_instance_of(File).to receive(:flock).twice.and_return(1)
+        expect_any_instance_of(File).to receive(:flock).once.and_return(1)
       end
 
       it { expect { |b| instance.with_exclusive_lock('some_lock', &b) }.to_not raise_error }

--- a/spec/masamune/thor_spec.rb
+++ b/spec/masamune/thor_spec.rb
@@ -235,4 +235,37 @@ describe Masamune::Thor do
       it { is_expected.to eq([[], ['--more']]) }
     end
   end
+
+  context '#qualify_task_name' do
+    let(:thor_class) do
+      Class.new(Thor) do
+        include Masamune::Thor
+      end
+    end
+
+    let(:instance) { thor_class.new([], {}, {}) }
+
+    before do
+      expect(instance).to receive(:current_namespace).at_most(:once).and_return('namespace')
+    end
+
+    subject do
+      instance.qualify_task_name(name)
+    end
+
+    context 'without namespace' do
+      let(:name) { 'other' }
+      it { is_expected.to eq('namespace:other') }
+    end
+
+    context 'with namespace' do
+      let(:name) { 'namespace:other' }
+      it { is_expected.to eq('namespace:other') }
+    end
+
+    context 'with task suffix' do
+      let(:name) { 'namespace:other_task' }
+      it { is_expected.to eq('namespace:other') }
+    end
+  end
 end


### PR DESCRIPTION
- Skip lock for shared utilities tasks, e.g. `hive`, `psql` 
- Fix bug with `command.name` not being associated with a namespace, causing tasks to be skipped