### PR TITLE
Encapsulate replace table logic into reusable transform

### DIFF
--- a/lib/masamune/transform/replace_table.psql.erb
+++ b/lib/masamune/transform/replace_table.psql.erb
@@ -1,0 +1,67 @@
+--  The MIT License (MIT)
+--
+--  Copyright (c) 2014-2015, VMware, Inc. All Rights Reserved.
+--
+--  Permission is hereby granted, free of charge, to any person obtaining a copy
+--  of this software and associated documentation files (the "Software"), to deal
+--  in the Software without restriction, including without limitation the rights
+--  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--  copies of the Software, and to permit persons to whom the Software is
+--  furnished to do so, subject to the following conditions:
+--
+--  The above copyright notice and this permission notice shall be included in
+--  all copies or substantial portions of the Software.
+--
+--  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+--  THE SOFTWARE.
+
+<%- target_tmp = target.stage_table(suffix: 'tmp')  %>
+
+SELECT pg_advisory_lock(ddl_advisory_lock());
+
+DROP TABLE IF EXISTS <%= target_tmp.name %> CASCADE;
+
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
+ALTER TABLE <%= target.name %> DROP CONSTRAINT IF EXISTS <%= target.name %>_time_key_check;
+<%- target.foreign_key_columns.each do |column| -%>
+<%- if column.reference_constraint -%>
+ALTER TABLE <%= target.name %> DROP CONSTRAINT IF EXISTS <%= target.name %>_<%= column.name %>_fkey CASCADE;
+<%- end -%>
+<%- end -%>
+
+<%- target.index_columns.each do |column_names, unique, id| -%>
+<%- index_name = "#{target.name}_#{id}_index" -%>
+DROP INDEX IF EXISTS <%= index_name %>;
+<%- end -%>
+
+ALTER TABLE <%= target.name %> RENAME TO <%= target_tmp.name %>;
+ALTER TABLE <%= source.name %> RENAME TO <%= target.name %>;
+
+ALTER TABLE <%= target.name %> INHERIT <%= target.parent.name %>;
+ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_time_key_check <%= target.constraints %>;
+<%- target.foreign_key_columns.each do |column| -%>
+<%- if column.reference_constraint -%>
+ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_<%= column.name %>_fkey FOREIGN KEY (<%= column.name %>) <%= column.reference_constraint %> NOT VALID DEFERRABLE INITIALLY DEFERRED;
+<%- end -%>
+<%- end -%>
+
+<%- target.index_columns.each do |column_names, unique, id| -%>
+<%- index_name = "#{target.name}_#{id}_index" -%>
+CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target.name %> (<%= column_names.join(', ') %>);
+<%- end -%>
+
+ANALYZE <%= target.name %>;
+
+COMMIT;
+
+DROP TABLE IF EXISTS <%= target_tmp.name %> CASCADE;
+DROP TABLE IF EXISTS <%= source.name %> CASCADE;
+
+SELECT pg_advisory_unlock(ddl_advisory_lock());

--- a/lib/masamune/transform/rollup_fact.psql.erb
+++ b/lib/masamune/transform/rollup_fact.psql.erb
@@ -30,6 +30,8 @@ DROP TABLE IF EXISTS <%= target_stage.name %>_tmp CASCADE;
 CREATE TABLE IF NOT EXISTS <%= target.name %> (LIKE <%= target.parent.name %> INCLUDING ALL);
 CREATE TABLE IF NOT EXISTS <%= target_stage.name %> (LIKE <%= target.parent.name %> INCLUDING ALL);
 
+BEGIN;
+
 INSERT INTO
   <%= target_stage.name %> (<%= target.insert_columns(source).join(', ') %>)
 SELECT
@@ -49,6 +51,8 @@ GROUP BY
   <%= value %><%= ',' unless last %>
   <%- end -%>
 ;
+
+COMMIT;
 
 SELECT pg_advisory_lock(ddl_advisory_lock());
 

--- a/lib/masamune/transform/rollup_fact.psql.erb
+++ b/lib/masamune/transform/rollup_fact.psql.erb
@@ -25,7 +25,6 @@
 SELECT pg_advisory_lock(<%= target_stage.lock_id %>);
 
 DROP TABLE IF EXISTS <%= target_stage.name %> CASCADE;
-DROP TABLE IF EXISTS <%= target_stage.name %>_tmp CASCADE;
 
 CREATE TABLE IF NOT EXISTS <%= target.name %> (LIKE <%= target.parent.name %> INCLUDING ALL);
 CREATE TABLE IF NOT EXISTS <%= target_stage.name %> (LIKE <%= target.parent.name %> INCLUDING ALL);
@@ -54,46 +53,6 @@ GROUP BY
 
 COMMIT;
 
-SELECT pg_advisory_lock(ddl_advisory_lock());
-
-BEGIN;
-SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
-
-ALTER TABLE <%= target.name %> DROP CONSTRAINT IF EXISTS <%= target.name %>_time_key_check;
-<%- target.foreign_key_columns.each do |column| -%>
-<%- if column.reference_constraint -%>
-ALTER TABLE <%= target.name %> DROP CONSTRAINT IF EXISTS <%= target.name %>_<%= column.name %>_fkey CASCADE;
-<%- end -%>
-<%- end -%>
-
-<%- target.index_columns.each do |column_names, unique, id| -%>
-<%- index_name = "#{target.name}_#{id}_index" -%>
-DROP INDEX IF EXISTS <%= index_name %>;
-<%- end -%>
-
-ALTER TABLE <%= target.name %> RENAME TO <%= target_stage.name %>_tmp;
-ALTER TABLE <%= target_stage.name %> RENAME TO <%= target.name %>;
-
-ALTER TABLE <%= target.name %> INHERIT <%= target.parent.name %>;
-ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_time_key_check <%= target.constraints %>;
-<%- target.foreign_key_columns.each do |column| -%>
-<%- if column.reference_constraint -%>
-ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_<%= column.name %>_fkey FOREIGN KEY (<%= column.name %>) <%= column.reference_constraint %> NOT VALID DEFERRABLE INITIALLY DEFERRED;
-<%- end -%>
-<%- end -%>
-
-<%- target.index_columns.each do |column_names, unique, id| -%>
-<%- index_name = "#{target.name}_#{id}_index" -%>
-CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target.name %> (<%= column_names.join(', ') %>);
-<%- end -%>
-
-ANALYZE <%= target.name %>;
-
-COMMIT;
-
-DROP TABLE IF EXISTS <%= target_stage.name %>_tmp CASCADE;
-DROP TABLE IF EXISTS <%= target_stage.name %> CASCADE;
-
-SELECT pg_advisory_unlock(ddl_advisory_lock());
+<%= render 'replace_table.psql.erb', source: target_stage, target: target %>
 
 SELECT pg_advisory_unlock(<%= target_stage.lock_id %>);

--- a/lib/masamune/transform/stage_fact.psql.erb
+++ b/lib/masamune/transform/stage_fact.psql.erb
@@ -31,6 +31,8 @@ DROP TABLE IF EXISTS <%= target_partition.name %>_tmp CASCADE;
 CREATE TABLE IF NOT EXISTS <%= target_stage.name %> (LIKE <%= target.name %> INCLUDING ALL);
 CREATE TABLE IF NOT EXISTS <%= target_partition.name %> (LIKE <%= target.name %> INCLUDING ALL);
 
+BEGIN;
+
 INSERT INTO
   <%= target_stage.name %> (<%= target.insert_columns(source).join(', ') %>)
 SELECT
@@ -46,6 +48,8 @@ ON
   <%= conditions.join(" AND\n  ") %>
 <%- end -%>
 ;
+
+COMMIT;
 
 SELECT pg_advisory_lock(ddl_advisory_lock());
 

--- a/lib/masamune/transform/stage_fact.psql.erb
+++ b/lib/masamune/transform/stage_fact.psql.erb
@@ -26,7 +26,6 @@
 SELECT pg_advisory_lock(<%= target_partition.lock_id %>);
 
 DROP TABLE IF EXISTS <%= target_stage.name %> CASCADE;
-DROP TABLE IF EXISTS <%= target_partition.name %>_tmp CASCADE;
 
 CREATE TABLE IF NOT EXISTS <%= target_stage.name %> (LIKE <%= target.name %> INCLUDING ALL);
 CREATE TABLE IF NOT EXISTS <%= target_partition.name %> (LIKE <%= target.name %> INCLUDING ALL);
@@ -51,46 +50,6 @@ ON
 
 COMMIT;
 
-SELECT pg_advisory_lock(ddl_advisory_lock());
-
-BEGIN;
-SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
-
-ALTER TABLE <%= target_partition.name %> DROP CONSTRAINT IF EXISTS <%= target_partition.name %>_time_key_check;
-<%- target.foreign_key_columns.each do |column| -%>
-<%- if column.reference_constraint -%>
-ALTER TABLE <%= target_partition.name %> DROP CONSTRAINT IF EXISTS <%= target_partition.name %>_<%= column.name %>_fkey CASCADE;
-<%- end -%>
-<%- end -%>
-
-<%- target_partition.index_columns.each do |column_names, unique, id| -%>
-<%- index_name = "#{target_partition.name}_#{id}_index" -%>
-DROP INDEX IF EXISTS <%= index_name %>;
-<%- end -%>
-
-ALTER TABLE <%= target_partition.name %> RENAME TO <%= target_partition.name %>_tmp;
-ALTER TABLE <%= target_stage.name %> RENAME TO <%= target_partition.name %>;
-
-ALTER TABLE <%= target_partition.name %> INHERIT <%= target.name %>;
-ALTER TABLE <%= target_partition.name %> ADD CONSTRAINT <%= target_partition.name %>_time_key_check <%= target_partition.constraints %>;
-<%- target.foreign_key_columns.each do |column| -%>
-<%- if column.reference_constraint -%>
-ALTER TABLE <%= target_partition.name %> ADD CONSTRAINT <%= target_partition.name %>_<%= column.name %>_fkey FOREIGN KEY (<%= column.name %>) <%= column.reference_constraint %> NOT VALID DEFERRABLE INITIALLY DEFERRED;
-<%- end -%>
-<%- end -%>
-
-<%- target_partition.index_columns.each do |column_names, unique, id| -%>
-<%- index_name = "#{target_partition.name}_#{id}_index" -%>
-CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target_partition.name %> (<%= column_names.join(', ') %>);
-<%- end -%>
-
-ANALYZE <%= target_partition.name %>;
-
-COMMIT;
-
-DROP TABLE IF EXISTS <%= target_partition.name %>_tmp CASCADE;
-DROP TABLE IF EXISTS <%= target_stage.name %> CASCADE;
-
-SELECT pg_advisory_unlock(ddl_advisory_lock());
+<%= render 'replace_table.psql.erb', source: target_stage, target: target_partition %>
 
 SELECT pg_advisory_unlock(<%= target_partition.lock_id %>);

--- a/spec/masamune/transform/rollup_fact_spec.rb
+++ b/spec/masamune/transform/rollup_fact_spec.rb
@@ -100,6 +100,8 @@ describe Masamune::Transform::RollupFact do
         CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08 (LIKE visits_hourly_fact INCLUDING ALL);
         CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08_stage (LIKE visits_hourly_fact INCLUDING ALL);
 
+        BEGIN;
+
         INSERT INTO
           visits_hourly_fact_y2014m08_stage (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
         SELECT
@@ -124,6 +126,8 @@ describe Masamune::Transform::RollupFact do
           visits_transaction_fact_y2014m08.feature_type_id,
           (visits_transaction_fact_y2014m08.time_key - (visits_transaction_fact_y2014m08.time_key % 3600))
         ;
+
+        COMMIT;
 
         SELECT pg_advisory_lock(ddl_advisory_lock());
 
@@ -197,6 +201,8 @@ describe Masamune::Transform::RollupFact do
         CREATE TABLE IF NOT EXISTS visits_daily_fact_y2014m08 (LIKE visits_daily_fact INCLUDING ALL);
         CREATE TABLE IF NOT EXISTS visits_daily_fact_y2014m08_stage (LIKE visits_daily_fact INCLUDING ALL);
 
+        BEGIN;
+
         INSERT INTO
           visits_daily_fact_y2014m08_stage (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
         SELECT
@@ -220,6 +226,8 @@ describe Masamune::Transform::RollupFact do
           visits_hourly_fact_y2014m08.user_agent_type_id,
           visits_hourly_fact_y2014m08.feature_type_id
         ;
+
+        COMMIT;
 
         SELECT pg_advisory_lock(ddl_advisory_lock());
 
@@ -293,6 +301,8 @@ describe Masamune::Transform::RollupFact do
         CREATE TABLE IF NOT EXISTS visits_monthly_fact_y2014m08 (LIKE visits_monthly_fact INCLUDING ALL);
         CREATE TABLE IF NOT EXISTS visits_monthly_fact_y2014m08_stage (LIKE visits_monthly_fact INCLUDING ALL);
 
+        BEGIN;
+
         INSERT INTO
           visits_monthly_fact_y2014m08_stage (date_dimension_id, tenant_dimension_id, user_dimension_id, user_agent_type_id, feature_type_id, total, time_key)
         SELECT
@@ -316,6 +326,8 @@ describe Masamune::Transform::RollupFact do
           visits_daily_fact_y2014m08.user_agent_type_id,
           visits_daily_fact_y2014m08.feature_type_id
         ;
+
+        COMMIT;
 
         SELECT pg_advisory_lock(ddl_advisory_lock());
 

--- a/spec/masamune/transform/rollup_fact_spec.rb
+++ b/spec/masamune/transform/rollup_fact_spec.rb
@@ -95,7 +95,6 @@ describe Masamune::Transform::RollupFact do
         SELECT pg_advisory_lock(42);
 
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage CASCADE;
-        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage_tmp CASCADE;
 
         CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08 (LIKE visits_hourly_fact INCLUDING ALL);
         CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08_stage (LIKE visits_hourly_fact INCLUDING ALL);
@@ -130,6 +129,8 @@ describe Masamune::Transform::RollupFact do
         COMMIT;
 
         SELECT pg_advisory_lock(ddl_advisory_lock());
+
+        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage_tmp CASCADE;
 
         BEGIN;
         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -196,7 +197,6 @@ describe Masamune::Transform::RollupFact do
         SELECT pg_advisory_lock(42);
 
         DROP TABLE IF EXISTS visits_daily_fact_y2014m08_stage CASCADE;
-        DROP TABLE IF EXISTS visits_daily_fact_y2014m08_stage_tmp CASCADE;
 
         CREATE TABLE IF NOT EXISTS visits_daily_fact_y2014m08 (LIKE visits_daily_fact INCLUDING ALL);
         CREATE TABLE IF NOT EXISTS visits_daily_fact_y2014m08_stage (LIKE visits_daily_fact INCLUDING ALL);
@@ -230,6 +230,8 @@ describe Masamune::Transform::RollupFact do
         COMMIT;
 
         SELECT pg_advisory_lock(ddl_advisory_lock());
+
+        DROP TABLE IF EXISTS visits_daily_fact_y2014m08_stage_tmp CASCADE;
 
         BEGIN;
         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -296,7 +298,6 @@ describe Masamune::Transform::RollupFact do
         SELECT pg_advisory_lock(42);
 
         DROP TABLE IF EXISTS visits_monthly_fact_y2014m08_stage CASCADE;
-        DROP TABLE IF EXISTS visits_monthly_fact_y2014m08_stage_tmp CASCADE;
 
         CREATE TABLE IF NOT EXISTS visits_monthly_fact_y2014m08 (LIKE visits_monthly_fact INCLUDING ALL);
         CREATE TABLE IF NOT EXISTS visits_monthly_fact_y2014m08_stage (LIKE visits_monthly_fact INCLUDING ALL);
@@ -330,6 +331,8 @@ describe Masamune::Transform::RollupFact do
         COMMIT;
 
         SELECT pg_advisory_lock(ddl_advisory_lock());
+
+        DROP TABLE IF EXISTS visits_monthly_fact_y2014m08_stage_tmp CASCADE;
 
         BEGIN;
         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -110,6 +110,8 @@ describe Masamune::Transform::StageFact do
         CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08_stage (LIKE visits_hourly_fact INCLUDING ALL);
         CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08 (LIKE visits_hourly_fact INCLUDING ALL);
 
+        BEGIN;
+
         INSERT INTO
           visits_hourly_fact_y2014m08_stage (date_dimension_id, tenant_dimension_id, user_dimension_id, group_dimension_id, user_agent_type_id, feature_type_id, session_type_id, total, time_key)
         SELECT
@@ -155,6 +157,8 @@ describe Masamune::Transform::StageFact do
         ON
           feature_type.name = visits_hourly_file_fact_stage.feature_type_name
         ;
+
+        COMMIT;
 
         SELECT pg_advisory_lock(ddl_advisory_lock());
 

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -105,7 +105,6 @@ describe Masamune::Transform::StageFact do
         SELECT pg_advisory_lock(42);
 
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage CASCADE;
-        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_tmp CASCADE;
 
         CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08_stage (LIKE visits_hourly_fact INCLUDING ALL);
         CREATE TABLE IF NOT EXISTS visits_hourly_fact_y2014m08 (LIKE visits_hourly_fact INCLUDING ALL);
@@ -162,6 +161,8 @@ describe Masamune::Transform::StageFact do
 
         SELECT pg_advisory_lock(ddl_advisory_lock());
 
+        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage_tmp CASCADE;
+
         BEGIN;
         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
@@ -184,7 +185,7 @@ describe Masamune::Transform::StageFact do
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_422efee_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_6444ed3_index;
 
-        ALTER TABLE visits_hourly_fact_y2014m08 RENAME TO visits_hourly_fact_y2014m08_tmp;
+        ALTER TABLE visits_hourly_fact_y2014m08 RENAME TO visits_hourly_fact_y2014m08_stage_tmp;
         ALTER TABLE visits_hourly_fact_y2014m08_stage RENAME TO visits_hourly_fact_y2014m08;
 
         ALTER TABLE visits_hourly_fact_y2014m08 INHERIT visits_hourly_fact;
@@ -211,7 +212,7 @@ describe Masamune::Transform::StageFact do
 
         COMMIT;
 
-        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_tmp CASCADE;
+        DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage_tmp CASCADE;
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage CASCADE;
 
         SELECT pg_advisory_unlock(ddl_advisory_lock());


### PR DESCRIPTION
Replace table via atomic swap can be used elsewhere, also encapsulation makes the code more readable