### PR TITLE
Compound primary key

### DIFF
--- a/bin/masamune-dump
+++ b/bin/masamune-dump
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+$: << File.expand_path('../../lib/', __FILE__)
+require 'masamune/tasks/dump_thor'
+Masamune::Tasks::DumpThor.start(ARGV)

--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -85,7 +85,6 @@ module Masamune::Schema
 
     def index=(value)
       @index ||= Set.new
-      @index.clear
       @index +=
       case value
       when true
@@ -103,7 +102,6 @@ module Masamune::Schema
 
     def unique=(value)
       @unique ||= Set.new
-      @unique.clear
       @unique +=
       case value
       when true

--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -83,6 +83,17 @@ module Masamune::Schema
       end
     end
 
+    def natural_key=(value)
+      @natural_key = value
+      if value
+        @unique ||= Set.new
+        @index ||= Set.new
+        @unique << :natural
+        @index << :natural
+      end
+      value
+    end
+
     def index=(value)
       @index ||= Set.new
       @index.clear
@@ -99,11 +110,6 @@ module Masamune::Schema
       else
         raise ArgumentError
       end
-    end
-
-    def unique
-      self.unique = 'natural' if natural_key
-      @unique
     end
 
     def unique=(value)

--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -477,7 +477,6 @@ module Masamune::Schema
     def sql_constraints
       [].tap do |constraints|
         constraints << 'NOT NULL' unless null || surrogate_key || !strict || parent.temporary? || degenerate?
-        constraints << "PRIMARY KEY" if surrogate_key
       end
     end
 

--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -83,17 +83,6 @@ module Masamune::Schema
       end
     end
 
-    def natural_key=(value)
-      @natural_key = value
-      if value
-        @unique ||= Set.new
-        @index ||= Set.new
-        @unique << :natural
-        @index << :natural
-      end
-      value
-    end
-
     def index=(value)
       @index ||= Set.new
       @index.clear
@@ -369,7 +358,7 @@ module Masamune::Schema
     end
 
     def as_psql
-      [name, sql_type(surrogate_key), *sql_constraints, reference_constraint, sql_default].compact.join(' ')
+      [name, sql_type(surrogate_key), *sql_constraints, sql_default].compact.join(' ')
     end
 
     def as_hql
@@ -381,16 +370,6 @@ module Masamune::Schema
         DEFAULT_ATTRIBUTES.keys.each do |attr|
           hash[attr] = public_send(attr)
         end
-      end
-    end
-
-    # TODO: Add ELEMENT REFERENCES
-    def reference_constraint
-      return if parent && parent.temporary?
-      return if degenerate?
-      return if array_value?
-      if reference && reference.surrogate_key.type == type
-        "REFERENCES #{reference.name}(#{reference.surrogate_key.name})"
       end
     end
 

--- a/lib/masamune/schema/dimension.rb
+++ b/lib/masamune/schema/dimension.rb
@@ -91,27 +91,28 @@ module Masamune::Schema
     end
 
     def initialize_dimension_columns!
+      # TODO assign index for load_fact
       case type
       when :one, :date
         initialize_column! id: 'last_modified_at', type: :timestamp, default: 'NOW()'
       when :two
-        initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: true, unique: 'natural'
-        initialize_column! id: 'end_at', type: :timestamp, null: true, index: true
-        initialize_column! id: 'version', type: :integer, default: 1, null: true, index: true
+        initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: :natural, unique: :natural
+        initialize_column! id: 'end_at', type: :timestamp, null: true
+        initialize_column! id: 'version', type: :integer, default: 1, null: true
         initialize_column! id: 'last_modified_at', type: :timestamp, default: 'NOW()'
       when :four
         children << ledger_table
         # FIXME derive type from from parent
         initialize_column! id: 'parent_id', type: :integer, null: true, reference: ledger_table
         initialize_column! id: 'record_id', type: :integer, null: true, reference: ledger_table
-        initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: true, unique: 'natural'
-        initialize_column! id: 'end_at', type: :timestamp, null: true, index: true
-        initialize_column! id: 'version', type: :integer, default: 1, null: true, index: true
+        initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: :natural, unique: :natural
+        initialize_column! id: 'end_at', type: :timestamp, null: true
+        initialize_column! id: 'version', type: :integer, default: 1, null: true
         initialize_column! id: 'last_modified_at', type: :timestamp, default: 'NOW()'
       when :ledger
-        initialize_column! id: 'source_kind', type: :string, unique: 'natural'
-        initialize_column! id: 'source_uuid', type: :string, unique: 'natural'
-        initialize_column! id: 'start_at', type: :timestamp, index: true, unique: 'natural'
+        initialize_column! id: 'source_kind', type: :string, index: :natural, unique: :natural
+        initialize_column! id: 'source_uuid', type: :string, index: :natural, unique: :natural
+        initialize_column! id: 'start_at', type: :timestamp, index: :natural, unique: :natural
         initialize_column! id: 'last_modified_at', type: :timestamp, default: 'NOW()'
         initialize_column! id: 'delta', type: :integer
       when :stage

--- a/lib/masamune/schema/dimension.rb
+++ b/lib/masamune/schema/dimension.rb
@@ -103,8 +103,8 @@ module Masamune::Schema
       when :four
         children << ledger_table
         # FIXME derive type from from parent
-        initialize_column! id: 'parent_id', type: :integer, null: true, reference: ledger_table
-        initialize_column! id: 'record_id', type: :integer, null: true, reference: ledger_table
+        initialize_column! id: 'parent_id', type: :integer, null: true, reference: TableReference.new(ledger_table)
+        initialize_column! id: 'record_id', type: :integer, null: true, reference: TableReference.new(ledger_table)
         initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: :natural, unique: :natural
         initialize_column! id: 'end_at', type: :timestamp, null: true
         initialize_column! id: 'version', type: :integer, default: 1, null: true

--- a/lib/masamune/schema/dimension.rb
+++ b/lib/masamune/schema/dimension.rb
@@ -96,8 +96,8 @@ module Masamune::Schema
       when :one, :date
         initialize_column! id: 'last_modified_at', type: :timestamp, default: 'NOW()'
       when :two
-        initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: :natural, unique: :natural
-        initialize_column! id: 'end_at', type: :timestamp, null: true
+        initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: [:start_at, :natural], unique: :natural
+        initialize_column! id: 'end_at', type: :timestamp, null: true, index: :end_at
         initialize_column! id: 'version', type: :integer, default: 1, null: true
         initialize_column! id: 'last_modified_at', type: :timestamp, default: 'NOW()'
       when :four
@@ -105,8 +105,8 @@ module Masamune::Schema
         # FIXME derive type from from parent
         initialize_column! id: 'parent_id', type: :integer, null: true, reference: TableReference.new(ledger_table)
         initialize_column! id: 'record_id', type: :integer, null: true, reference: TableReference.new(ledger_table)
-        initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: :natural, unique: :natural
-        initialize_column! id: 'end_at', type: :timestamp, null: true
+        initialize_column! id: 'start_at', type: :timestamp, default: 'TO_TIMESTAMP(0)', index: [:start_at, :natural], unique: :natural
+        initialize_column! id: 'end_at', type: :timestamp, null: true, index: :end_at
         initialize_column! id: 'version', type: :integer, default: 1, null: true
         initialize_column! id: 'last_modified_at', type: :timestamp, default: 'NOW()'
       when :ledger

--- a/lib/masamune/schema/fact.rb
+++ b/lib/masamune/schema/fact.rb
@@ -34,7 +34,8 @@ module Masamune::Schema
       @partition = opts.delete(:partition)
       super opts.reverse_merge(type: :fact)
       initialize_fact_columns!
-      foreign_key_columns.each do |column|
+      reference_columns.each do |column|
+        column.index.clear
         column.index << column.name
       end
       time_key.index << time_key.name
@@ -57,6 +58,10 @@ module Masamune::Schema
 
     def date_column
       columns.select { |_, column| column && column.reference && column.reference.type == :date }.values.first
+    end
+
+    def primary_keys
+      []
     end
 
     def time_key

--- a/lib/masamune/schema/fact.rb
+++ b/lib/masamune/schema/fact.rb
@@ -37,6 +37,10 @@ module Masamune::Schema
       reference_columns.each do |column|
         column.index.clear
         column.index << column.name
+        if type == :stage
+          column.index << "#{column.name}_time_key"
+          time_key.index << "#{column.name}_time_key"
+        end
       end
       time_key.index << time_key.name
     end

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -335,7 +335,7 @@ module Masamune::Schema
             map[index] << column.name
           end
         end
-        Hash[map.sort_by { |k, v| v.length }]
+        Hash[map.sort_by { |k, v| [v.length, k.to_s] }]
       end
     end
 
@@ -349,7 +349,7 @@ module Masamune::Schema
             map[unique] << column.name
           end
         end unless temporary?
-        Hash[map.sort_by { |k, v| v.length }]
+        Hash[map.sort_by { |k, v| [v.length, k.to_s] }]
       end
     end
 

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -329,10 +329,11 @@ module Masamune::Schema
 
     def index_column_map
       @index_column_map ||= begin
-        map = Hash.new { |h,k| h[k] = Set.new }
+        map = Hash.new { |h,k| h[k] = [] }
         columns.each do |_, column|
           column.index.each do |index|
             map[index] << column.name
+            map[index].uniq!
           end
         end
         Hash[map.sort_by { |k, v| [v.length, k.to_s] }]
@@ -341,12 +342,13 @@ module Masamune::Schema
 
     def unique_constraints_map
       @unique_constraints_map ||= begin
-        map = Hash.new { |h,k| h[k] = Set.new }
+        map = Hash.new { |h,k| h[k] = [] }
         columns.each do |_, column|
           next if column.auto_reference
           column.unique.each do |unique|
             map[unique] += auto_surrogate_keys.map(&:name)
             map[unique] << column.name
+            map[unique].uniq!
           end
         end unless temporary?
         Hash[map.sort_by { |k, v| [v.length, k.to_s] }]

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -325,10 +325,11 @@ module Masamune::Schema
 
     def initialize_column!(column_or_options)
       column = column_or_options.is_a?(Column) ? column_or_options.dup : Column.new(column_or_options.merge(parent: self))
-      @columns[column.name.to_sym] = column
-      @columns[column.name.to_sym].parent = self
-      @columns[column.name.to_sym].index << :natural if column.natural_key
-      @columns[column.name.to_sym].unique << :natural if column.natural_key
+      column_key = column.name.to_sym
+      @columns[column_key] = column
+      @columns[column_key].parent = self
+      @columns[column_key].index += [column_key, :natural] if column.natural_key
+      @columns[column_key].unique << :natural if column.natural_key
     end
 
     def index_column_map

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -247,11 +247,6 @@ module Masamune::Schema
       Integer('0x' + Digest::MD5.hexdigest(name)) % (1 << 63)
     end
 
-    # TODO move into presenter
-    def short_md5(*a)
-      Digest::MD5.hexdigest(a.join('_'))[0..6]
-    end
-
     def auto_surrogate_keys
       columns.values.select { |column| column.reference && column.reference.surrogate_key.auto }.uniq.compact
     end
@@ -360,6 +355,10 @@ module Masamune::Schema
 
     def reverse_unique_constraints_map
       @reverse_unique_constraints_map ||= Hash[unique_constraints_map.to_a.map { |k,v| [v.sort, k] }]
+    end
+
+    def short_md5(*a)
+      Digest::MD5.hexdigest(a.compact.sort.uniq.join('_'))[0..6]
     end
   end
 end

--- a/lib/masamune/tasks/dump_thor.rb
+++ b/lib/masamune/tasks/dump_thor.rb
@@ -35,6 +35,9 @@ module Masamune::Tasks
 
     desc 'dump', 'Dump schema'
     method_option :type, :enum => ['psql', 'hql'], :desc => 'Schema type', :default => 'psql'
+    method_option :with_index, :type => :boolean, :desc => 'Dump schema with indexes', :default => true
+    method_option :with_foreign_key, :type => :boolean, :desc => 'Dump schema with foreign key constraints', :default => true
+    method_option :with_unique_constraint, :type => :boolean, :desc => 'Dump schema with uniqueness constraints', :default => true
     def dump_exec
       print_catalog
       exit
@@ -46,7 +49,7 @@ module Masamune::Tasks
     def print_catalog
       case options[:type]
       when 'psql'
-        puts define_schema(catalog, :postgres)
+        puts define_schema(catalog, :postgres, options.slice(:with_index, :with_foreign_key, :with_unique_constraint).to_h.symbolize_keys)
       when 'hql'
         puts define_schema(catalog, :hive)
       end

--- a/lib/masamune/tasks/dump_thor.rb
+++ b/lib/masamune/tasks/dump_thor.rb
@@ -22,24 +22,34 @@
 
 require 'masamune'
 require 'thor'
-require 'pry'
 
 module Masamune::Tasks
-  class ShellThor < Thor
+  class DumpThor < Thor
     include Masamune::Thor
-    include Masamune::Actions::DataFlow
+    include Masamune::Transform::DefineSchema
 
     # FIXME need to add an unnecessary namespace until this issue is fixed:
     # https://github.com/wycats/thor/pull/247
-    namespace :shell
+    namespace :dump
     skip_lock!
 
-    desc 'shell', 'Launch an interactive shell'
-    method_option :prompt, :desc => 'Set shell prompt', :default => 'masamune'
-    class_option :start, :aliases => '-a', :desc => 'Start time', default: '1 month ago'
-    def shell_exec
-      Pry.start self, prompt: proc { options[:prompt] + '> ' }
+    desc 'dump', 'Dump schema'
+    method_option :type, :enum => ['psql', 'hql'], :desc => 'Schema type', :default => 'psql'
+    def dump_exec
+      print_catalog
+      exit
     end
-    default_task :shell_exec
+    default_task :dump_exec
+
+    private
+
+    def print_catalog
+      case options[:type]
+      when 'psql'
+        puts define_schema(catalog, :postgres)
+      when 'hql'
+        puts define_schema(catalog, :hive)
+      end
+    end
   end
 end

--- a/lib/masamune/template.rb
+++ b/lib/masamune/template.rb
@@ -27,6 +27,7 @@ module Masamune
   class Template
     def initialize(paths = [])
       @paths = Array.wrap(paths)
+      @paths << File.join(File.dirname(__FILE__), 'transform')
     end
 
     def render(template, parameters = {})
@@ -48,7 +49,6 @@ module Masamune
 
     class << self
       def render_to_file(template, parameters = {})
-        raise IOError, "File not found: #{template}" unless File.exists?(template)
         Tempfile.new('masamune').tap do |file|
           file.write(render_to_string(template, parameters))
           file.close
@@ -56,7 +56,6 @@ module Masamune
       end
 
       def render_to_string(template, parameters = {})
-        raise IOError, "File not found: #{template}" unless File.exists?(template)
         instance = Template.new(File.dirname(template))
         combine instance.render(template, parameters)
       end

--- a/lib/masamune/transform/define_foreign_key.psql.erb
+++ b/lib/masamune/transform/define_foreign_key.psql.erb
@@ -29,7 +29,7 @@
 <%- foreign_key_name = "#{target.name}_#{id}_fkey" -%>
 <%- unless target.temporary? || skip_check_exist -%>
 DO $$ BEGIN
-IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= '<%= foreign_key_name %>') THEN
+IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = '<%= foreign_key_name %>') THEN
 <%- end -%>
 ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= foreign_key_name %> FOREIGN KEY (<%= column_names.join(', ') %>) REFERENCES <%= reference_name %>(<%= reference_column_names.join(', ') %>)<%= ' NOT VALID DEFERRABLE INITIALLY DEFERRED' if skip_check_valid %>;
 <%- unless target.temporary? || skip_check_exist -%>

--- a/lib/masamune/transform/define_foreign_key.psql.erb
+++ b/lib/masamune/transform/define_foreign_key.psql.erb
@@ -22,15 +22,16 @@
 
 <%
   skip_check_exist ||= false
+  skip_check_valid ||= false
 %>
 
-<%- target.index_columns.each do |column_names, unique, id| -%>
-<%- index_name = "#{target.name}_#{id}_index" -%>
+<%- target.foreign_key_constraints.each do |id, column_names, reference_name, reference_column_names| -%>
+<%- foreign_key_name = "#{target.name}_#{id}_fkey" -%>
 <%- unless target.temporary? || skip_check_exist -%>
 DO $$ BEGIN
-IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= index_name %>') THEN
+IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= '<%= foreign_key_name %>') THEN
 <%- end -%>
-CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target.name %> (<%= column_names.to_a.join(', ') %>);
+ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= foreign_key_name %> FOREIGN KEY (<%= column_names.join(', ') %>) REFERENCES <%= reference_name %>(<%= reference_column_names.join(', ') %>)<%= ' NOT VALID DEFERRABLE INITIALLY DEFERRED' if skip_check_valid %>;
 <%- unless target.temporary? || skip_check_exist -%>
 END IF; END $$;
 

--- a/lib/masamune/transform/define_index.psql.erb
+++ b/lib/masamune/transform/define_index.psql.erb
@@ -26,7 +26,7 @@
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= index_name %>') THEN
 <%- end -%>
-CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target.name %> (<%= column_names.join(', ') %>);
+CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target.name %> (<%= column_names.to_a.join(', ') %>);
 <%- unless target.temporary? -%>
 END IF; END $$;
 

--- a/lib/masamune/transform/define_schema.rb
+++ b/lib/masamune/transform/define_schema.rb
@@ -28,18 +28,18 @@ module Masamune::Transform
 
     extend ActiveSupport::Concern
 
-    def define_schema(catalog, store_id)
+    def define_schema(catalog, store_id, options = {})
       context = catalog[store_id]
       operators = []
 
       operators += context.extra(:pre)
 
       context.dimensions.each do |_, dimension|
-        operators << define_table(dimension)
+        operators << define_table(dimension, [], options)
       end
 
       context.facts.each do |_, fact|
-        operators << define_table(fact)
+        operators << define_table(fact, [], options)
       end
 
       operators += context.extra(:post)

--- a/lib/masamune/transform/define_table.psql.erb
+++ b/lib/masamune/transform/define_table.psql.erb
@@ -20,10 +20,15 @@
 --  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 --  THE SOFTWARE.
 
-<% files ||= [] %>
+<%
+  files ||= []
+  with_index = locals.fetch(:with_index, true)
+  with_foreign_key = locals.fetch(:with_foreign_key, true)
+  with_unique_constraint = locals.fetch(:with_unique_constraint, true)
+%>
 
 <%- target.children.each do |child| -%>
-<%= render 'define_table.psql.erb', target: child %>
+<%= render 'define_table.psql.erb', target: child, **locals.except(:target, :files)  %>
 <%- end -%>
 
 <%- target.enum_columns.each do |_, column| -%>
@@ -59,7 +64,7 @@ ALTER TABLE <%= target.name %> ADD PRIMARY KEY (<%= target.primary_keys.map(&:na
 END IF; END $$;
 <%- end -%>
 
-<%- unless target.delay_constraints? -%>
+<%- if with_foreign_key && !target.delay_constraints? -%>
 <%= render 'define_foreign_key.psql.erb', target: target %>
 <%- end -%>
 
@@ -80,11 +85,11 @@ END IF; END $$;
 COPY <%= target.name %> FROM '<%= file %>' WITH (<%= copy_options.join(", ") %>);
 <%- end -%>
 
-<%- unless target.delay_constraints? -%>
+<%- if with_unique_constraint && !target.delay_constraints? -%>
 <%= render 'define_unique.psql.erb', target: target %>
 <%- end -%>
 
-<%- unless target.delay_index? -%>
+<%- if with_index && !target.delay_index? -%>
 <%= render 'define_index.psql.erb', target: target %>
 <%- end -%>
 

--- a/lib/masamune/transform/define_table.psql.erb
+++ b/lib/masamune/transform/define_table.psql.erb
@@ -52,6 +52,13 @@ CREATE TABLE IF NOT EXISTS <%= target.name %>
   <%- end -%>
 );
 
+<%- if target.surrogate_key -%>
+DO $$ BEGIN
+IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= target.name %>_pkey') THEN
+ALTER TABLE <%= target.name %> ADD PRIMARY KEY (<%= target.surrogate_key.name %>);
+END IF; END $$;
+<%- end -%>
+
 <%- target.sequence_columns.each do |_, column| -%>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 WHERE sequence_owner('<%= column.sequence_id %>') = '<%= column.qualified_name %>') THEN

--- a/lib/masamune/transform/define_table.psql.erb
+++ b/lib/masamune/transform/define_table.psql.erb
@@ -52,11 +52,15 @@ CREATE TABLE IF NOT EXISTS <%= target.name %>
   <%- end -%>
 );
 
-<%- if target.surrogate_key -%>
+<%- unless target.temporary? || target.primary_keys.empty? -%>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= target.name %>_pkey') THEN
-ALTER TABLE <%= target.name %> ADD PRIMARY KEY (<%= target.surrogate_key.name %>);
+ALTER TABLE <%= target.name %> ADD PRIMARY KEY (<%= target.primary_keys.map(&:name).join(', ') %>);
 END IF; END $$;
+<%- end -%>
+
+<%- unless target.delay_constraints? -%>
+<%= render 'define_foreign_key.psql.erb', target: target %>
 <%- end -%>
 
 <%- target.sequence_columns.each do |_, column| -%>
@@ -76,8 +80,13 @@ END IF; END $$;
 COPY <%= target.name %> FROM '<%= file %>' WITH (<%= copy_options.join(", ") %>);
 <%- end -%>
 
+<%- unless target.delay_constraints? -%>
 <%= render 'define_unique.psql.erb', target: target %>
+<%- end -%>
+
+<%- unless target.delay_index? -%>
 <%= render 'define_index.psql.erb', target: target %>
+<%- end -%>
 
 <% target.insert_rows.each do |row| %>
 INSERT INTO <%= target.name %> (<%= row.insert_columns.join(', ') %>)

--- a/lib/masamune/transform/define_table.rb
+++ b/lib/masamune/transform/define_table.rb
@@ -24,9 +24,9 @@ module Masamune::Transform
   module DefineTable
     extend ActiveSupport::Concern
 
-    def define_table(target, files = [])
+    def define_table(target, files = [], options = {})
       return if target.implicit
-      Operator.new(__method__, target: target, files: Masamune::Schema::Map.convert_files(files), presenters: { postgres: Postgres, hive: Hive }).tap do |operator|
+      Operator.new(__method__, target: target, files: Masamune::Schema::Map.convert_files(files), **options.slice(:with_index, :with_foreign_key, :with_unique_constraint), presenters: { postgres: Postgres, hive: Hive }).tap do |operator|
         logger.debug("#{target.id}\n" + operator.to_s) if target.debug
       end
     end

--- a/lib/masamune/transform/define_table.rb
+++ b/lib/masamune/transform/define_table.rb
@@ -26,8 +26,22 @@ module Masamune::Transform
 
     def define_table(target, files = [])
       return if target.implicit
-      Operator.new(__method__, target: target, files: Masamune::Schema::Map.convert_files(files), presenters: { hive: Hive }).tap do |operator|
+      Operator.new(__method__, target: target, files: Masamune::Schema::Map.convert_files(files), presenters: { postgres: Postgres, hive: Hive }).tap do |operator|
         logger.debug("#{target.id}\n" + operator.to_s) if target.debug
+      end
+    end
+
+    class Postgres < SimpleDelegator
+      def children
+        super.map { |child| self.class.new(child) }
+      end
+
+      def delay_index?
+        type == :fact
+      end
+
+      def delay_constraints?
+        type == :fact
       end
     end
 

--- a/lib/masamune/transform/define_unique.psql.erb
+++ b/lib/masamune/transform/define_unique.psql.erb
@@ -24,7 +24,7 @@
 <%- constraint_name = "#{target.name}_#{id}_key" -%>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= constraint_name %>') THEN
-ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= constraint_name %> UNIQUE(<%= column_names.join(', ') %>);
+ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= constraint_name %> UNIQUE(<%= column_names.to_a.join(', ') %>);
 END IF; END $$;
 
 <%- end -%>

--- a/lib/masamune/transform/replace_table.psql.erb
+++ b/lib/masamune/transform/replace_table.psql.erb
@@ -43,8 +43,12 @@ DROP INDEX IF EXISTS <%= index_name %>;
 ALTER TABLE <%= target.name %> RENAME TO <%= target_tmp.name %>;
 ALTER TABLE <%= source.name %> RENAME TO <%= target.name %>;
 
+<%- if target.parent -%>
 ALTER TABLE <%= target.name %> INHERIT <%= target.parent.name %>;
+<%- end -%>
+<%- if target.constraints -%>
 ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_time_key_check <%= target.constraints %>;
+<%- end -%>
 <%= render 'define_foreign_key.psql.erb', target: target, skip_check_exist: true, skip_check_valid: true %>
 
 <%= render 'define_index.psql.erb', target: target, skip_check_exist: true %>

--- a/lib/masamune/transform/replace_table.psql.erb
+++ b/lib/masamune/transform/replace_table.psql.erb
@@ -54,7 +54,7 @@ ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_<%= column.name
 
 <%- target.index_columns.each do |column_names, unique, id| -%>
 <%- index_name = "#{target.name}_#{id}_index" -%>
-CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target.name %> (<%= column_names.join(', ') %>);
+CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target.name %> (<%= column_names.to_a.join(', ') %>);
 <%- end -%>
 
 ANALYZE <%= target.name %>;

--- a/lib/masamune/transform/replace_table.psql.erb
+++ b/lib/masamune/transform/replace_table.psql.erb
@@ -30,13 +30,12 @@ BEGIN;
 SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
 ALTER TABLE <%= target.name %> DROP CONSTRAINT IF EXISTS <%= target.name %>_time_key_check;
-<%- target.foreign_key_columns.each do |column| -%>
-<%- if column.reference_constraint -%>
-ALTER TABLE <%= target.name %> DROP CONSTRAINT IF EXISTS <%= target.name %>_<%= column.name %>_fkey CASCADE;
-<%- end -%>
+<%- target.foreign_key_constraints.each do |id, _, _, _| -%>
+<%- foreign_key_name = "#{target.name}_#{id}_fkey" -%>
+ALTER TABLE <%= target.name %> DROP CONSTRAINT IF EXISTS <%= foreign_key_name %> CASCADE;
 <%- end -%>
 
-<%- target.index_columns.each do |column_names, unique, id| -%>
+<%- target.index_columns.each do |_, _, id| -%>
 <%- index_name = "#{target.name}_#{id}_index" -%>
 DROP INDEX IF EXISTS <%= index_name %>;
 <%- end -%>
@@ -46,16 +45,9 @@ ALTER TABLE <%= source.name %> RENAME TO <%= target.name %>;
 
 ALTER TABLE <%= target.name %> INHERIT <%= target.parent.name %>;
 ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_time_key_check <%= target.constraints %>;
-<%- target.foreign_key_columns.each do |column| -%>
-<%- if column.reference_constraint -%>
-ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_<%= column.name %>_fkey FOREIGN KEY (<%= column.name %>) <%= column.reference_constraint %> NOT VALID DEFERRABLE INITIALLY DEFERRED;
-<%- end -%>
-<%- end -%>
+<%= render 'define_foreign_key.psql.erb', target: target, skip_check_exist: true, skip_check_valid: true %>
 
-<%- target.index_columns.each do |column_names, unique, id| -%>
-<%- index_name = "#{target.name}_#{id}_index" -%>
-CREATE <%= unique ? 'UNIQUE INDEX' : 'INDEX' %> <%= index_name %> ON <%= target.name %> (<%= column_names.to_a.join(', ') %>);
-<%- end -%>
+<%= render 'define_index.psql.erb', target: target, skip_check_exist: true %>
 
 ANALYZE <%= target.name %>;
 

--- a/masamune.gemspec
+++ b/masamune.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{bin,lib,spec/support/masamune}/**/*'] + ['LICENSE.txt', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
   s.require_path = 'lib'
-  s.executables = ['masamune-shell', 'masamune-hive', 'masamune-elastic-mapreduce', 'masamune-psql']
+  s.executables = ['masamune-shell', 'masamune-hive', 'masamune-elastic-mapreduce', 'masamune-psql', 'masamune-dump']
 
   s.add_dependency('thor')
   s.add_dependency('activesupport')

--- a/spec/masamune/tasks/dump_thor_spec.rb
+++ b/spec/masamune/tasks/dump_thor_spec.rb
@@ -20,26 +20,23 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-require 'masamune'
+require 'spec_helper'
 require 'thor'
-require 'pry'
 
-module Masamune::Tasks
-  class ShellThor < Thor
-    include Masamune::Thor
-    include Masamune::Actions::DataFlow
+require 'masamune/tasks/dump_thor'
 
-    # FIXME need to add an unnecessary namespace until this issue is fixed:
-    # https://github.com/wycats/thor/pull/247
-    namespace :shell
-    skip_lock!
+describe Masamune::Tasks::DumpThor do
+  context 'with help command ' do
+    let(:command) { 'help' }
+    it_behaves_like 'command usage'
+  end
 
-    desc 'shell', 'Launch an interactive shell'
-    method_option :prompt, :desc => 'Set shell prompt', :default => 'masamune'
-    class_option :start, :aliases => '-a', :desc => 'Start time', default: '1 month ago'
-    def shell_exec
-      Pry.start self, prompt: proc { options[:prompt] + '> ' }
+  context 'with no arguments' do
+    it 'exits with status code 0 and prints catalog' do
+      expect { cli_invocation }.to raise_error { |e|
+        expect(e).to be_a(SystemExit)
+        expect(e.status).to eq(0)
+      }
     end
-    default_task :shell_exec
   end
 end

--- a/spec/masamune/tasks/shell_thor_spec.rb
+++ b/spec/masamune/tasks/shell_thor_spec.rb
@@ -37,15 +37,4 @@ describe Masamune::Tasks::ShellThor do
       cli_invocation
     end
   end
-
-  context 'with --dump' do
-    let(:options) { ['--dump'] }
-
-    it 'exits with status code 0 and prints catalog' do
-      expect { cli_invocation }.to raise_error { |e|
-        expect(e).to be_a(SystemExit)
-        expect(e.status).to eq(0)
-      }
-    end
-  end
 end

--- a/spec/masamune/template_spec.rb
+++ b/spec/masamune/template_spec.rb
@@ -73,5 +73,10 @@ describe Masamune::Template do
       let(:template) { File.join(File.dirname(__FILE__), '..', 'fixtures', 'relative.sql.erb') }
       it { is_expected.to eq("SELECT * FROM relative;\n") }
     end
+
+    context 'with packaged template' do
+      let(:template) { 'define_schema.hql.erb' }
+      it { is_expected.to_not be_nil }
+    end
   end
 end

--- a/spec/masamune/transform/define_table.dimension_spec.rb
+++ b/spec/masamune/transform/define_table.dimension_spec.rb
@@ -264,12 +264,12 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_ledger_d6b9b38_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_dimension_ledger_d6b9b38_fkey') THEN
         ALTER TABLE user_dimension_ledger ADD CONSTRAINT user_dimension_ledger_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_ledger_7988187_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_dimension_ledger_7988187_fkey') THEN
         ALTER TABLE user_dimension_ledger ADD CONSTRAINT user_dimension_ledger_7988187_fkey FOREIGN KEY (user_account_state_type_id) REFERENCES user_account_state_type(id);
         END IF; END $$;
 
@@ -305,22 +305,22 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_d6b9b38_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_dimension_d6b9b38_fkey') THEN
         ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_7988187_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_dimension_7988187_fkey') THEN
         ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_7988187_fkey FOREIGN KEY (user_account_state_type_id) REFERENCES user_account_state_type(id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_e0538bc_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_dimension_e0538bc_fkey') THEN
         ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_e0538bc_fkey FOREIGN KEY (cluster_type_id, parent_id) REFERENCES user_dimension_ledger(cluster_type_id, id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_824002d_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_dimension_824002d_fkey') THEN
         ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_824002d_fkey FOREIGN KEY (cluster_type_id, record_id) REFERENCES user_dimension_ledger(cluster_type_id, id);
         END IF; END $$;
 

--- a/spec/masamune/transform/define_table.dimension_spec.rb
+++ b/spec/masamune/transform/define_table.dimension_spec.rb
@@ -157,11 +157,16 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_dimension
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL,
           last_modified_at TIMESTAMP NOT NULL DEFAULT NOW()
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_pkey') THEN
+        ALTER TABLE user_dimension ADD PRIMARY KEY (id);
+        END IF; END $$;
       EOS
     end
   end
@@ -182,7 +187,7 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_dimension
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL,
           start_at TIMESTAMP NOT NULL DEFAULT TO_TIMESTAMP(0),
@@ -190,6 +195,11 @@ describe Masamune::Transform::DefineTable do
           version INTEGER DEFAULT 1,
           last_modified_at TIMESTAMP NOT NULL DEFAULT NOW()
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_pkey') THEN
+        ALTER TABLE user_dimension ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_key') THEN
@@ -255,7 +265,7 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_dimension_ledger
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           cluster_type_id INTEGER NOT NULL REFERENCES cluster_type(id) DEFAULT default_cluster_type_id(),
           user_account_state_type_id INTEGER REFERENCES user_account_state_type(id),
           tenant_id INTEGER NOT NULL,
@@ -267,6 +277,11 @@ describe Masamune::Transform::DefineTable do
           last_modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
           delta INTEGER NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_pkey') THEN
+        ALTER TABLE user_dimension_ledger ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_370d6dd_key') THEN
@@ -300,7 +315,7 @@ describe Masamune::Transform::DefineTable do
 
         CREATE TABLE IF NOT EXISTS user_dimension
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           cluster_type_id INTEGER NOT NULL REFERENCES cluster_type(id) DEFAULT default_cluster_type_id(),
           user_account_state_type_id INTEGER NOT NULL REFERENCES user_account_state_type(id) DEFAULT default_user_account_state_type_id(),
           tenant_id INTEGER NOT NULL,
@@ -313,6 +328,11 @@ describe Masamune::Transform::DefineTable do
           version INTEGER DEFAULT 1,
           last_modified_at TIMESTAMP NOT NULL DEFAULT NOW()
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_pkey') THEN
+        ALTER TABLE user_dimension ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_key') THEN

--- a/spec/masamune/transform/define_table.dimension_spec.rb
+++ b/spec/masamune/transform/define_table.dimension_spec.rb
@@ -207,11 +207,6 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
-        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2c8e908_index') THEN
         CREATE INDEX user_dimension_2c8e908_index ON user_dimension (end_at);
         END IF; END $$;
@@ -219,6 +214,11 @@ describe Masamune::Transform::DefineTable do
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_23563d3_index') THEN
         CREATE INDEX user_dimension_23563d3_index ON user_dimension (start_at);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
+        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
@@ -360,11 +360,6 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
-        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2c8e908_index') THEN
         CREATE INDEX user_dimension_2c8e908_index ON user_dimension (end_at);
         END IF; END $$;
@@ -372,6 +367,11 @@ describe Masamune::Transform::DefineTable do
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_23563d3_index') THEN
         CREATE INDEX user_dimension_23563d3_index ON user_dimension (start_at);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
+        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
@@ -423,9 +423,9 @@ describe Masamune::Transform::DefineTable do
           last_modified_at TIMESTAMP DEFAULT NOW()
         );
 
-        CREATE INDEX user_consolidated_forward_dimension_stage_3854361_index ON user_consolidated_forward_dimension_stage (tenant_id);
         CREATE INDEX user_consolidated_forward_dimension_stage_2c8e908_index ON user_consolidated_forward_dimension_stage (end_at);
         CREATE INDEX user_consolidated_forward_dimension_stage_23563d3_index ON user_consolidated_forward_dimension_stage (start_at);
+        CREATE INDEX user_consolidated_forward_dimension_stage_3854361_index ON user_consolidated_forward_dimension_stage (tenant_id);
         CREATE INDEX user_consolidated_forward_dimension_stage_e8701ad_index ON user_consolidated_forward_dimension_stage (user_id);
         CREATE INDEX user_consolidated_forward_dimension_stage_e6c3d91_index ON user_consolidated_forward_dimension_stage (tenant_id, user_id, start_at);
       EOS

--- a/spec/masamune/transform/define_table.dimension_spec.rb
+++ b/spec/masamune/transform/define_table.dimension_spec.rb
@@ -207,6 +207,26 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
+        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2c8e908_index') THEN
+        CREATE INDEX user_dimension_2c8e908_index ON user_dimension (end_at);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_23563d3_index') THEN
+        CREATE INDEX user_dimension_23563d3_index ON user_dimension (start_at);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e8701ad_index') THEN
+        CREATE INDEX user_dimension_e8701ad_index ON user_dimension (user_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_index') THEN
         CREATE UNIQUE INDEX user_dimension_e6c3d91_index ON user_dimension (tenant_id, user_id, start_at);
         END IF; END $$;
@@ -279,6 +299,16 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_3854361_index') THEN
+        CREATE INDEX user_dimension_ledger_3854361_index ON user_dimension_ledger (tenant_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_e8701ad_index') THEN
+        CREATE INDEX user_dimension_ledger_e8701ad_index ON user_dimension_ledger (user_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_370d6dd_index') THEN
         CREATE INDEX user_dimension_ledger_370d6dd_index ON user_dimension_ledger (tenant_id, user_id, source_kind, source_uuid, start_at);
         END IF; END $$;
@@ -330,6 +360,26 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
+        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2c8e908_index') THEN
+        CREATE INDEX user_dimension_2c8e908_index ON user_dimension (end_at);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_23563d3_index') THEN
+        CREATE INDEX user_dimension_23563d3_index ON user_dimension (start_at);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e8701ad_index') THEN
+        CREATE INDEX user_dimension_e8701ad_index ON user_dimension (user_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_index') THEN
         CREATE INDEX user_dimension_e6c3d91_index ON user_dimension (tenant_id, user_id, start_at);
         END IF; END $$;
@@ -373,6 +423,10 @@ describe Masamune::Transform::DefineTable do
           last_modified_at TIMESTAMP DEFAULT NOW()
         );
 
+        CREATE INDEX user_consolidated_forward_dimension_stage_3854361_index ON user_consolidated_forward_dimension_stage (tenant_id);
+        CREATE INDEX user_consolidated_forward_dimension_stage_2c8e908_index ON user_consolidated_forward_dimension_stage (end_at);
+        CREATE INDEX user_consolidated_forward_dimension_stage_23563d3_index ON user_consolidated_forward_dimension_stage (start_at);
+        CREATE INDEX user_consolidated_forward_dimension_stage_e8701ad_index ON user_consolidated_forward_dimension_stage (user_id);
         CREATE INDEX user_consolidated_forward_dimension_stage_e6c3d91_index ON user_consolidated_forward_dimension_stage (tenant_id, user_id, start_at);
       EOS
     end

--- a/spec/masamune/transform/define_table.dimension_spec.rb
+++ b/spec/masamune/transform/define_table.dimension_spec.rb
@@ -246,8 +246,8 @@ describe Masamune::Transform::DefineTable do
         CREATE TABLE IF NOT EXISTS user_dimension_ledger
         (
           id SERIAL,
-          cluster_type_id INTEGER NOT NULL REFERENCES cluster_type(id) DEFAULT default_cluster_type_id(),
-          user_account_state_type_id INTEGER REFERENCES user_account_state_type(id),
+          cluster_type_id INTEGER NOT NULL DEFAULT default_cluster_type_id(),
+          user_account_state_type_id INTEGER,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL,
           preferences HSTORE,
@@ -260,7 +260,17 @@ describe Masamune::Transform::DefineTable do
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_pkey') THEN
-        ALTER TABLE user_dimension_ledger ADD PRIMARY KEY (id);
+        ALTER TABLE user_dimension_ledger ADD PRIMARY KEY (cluster_type_id, id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_ledger_d6b9b38_fkey') THEN
+        ALTER TABLE user_dimension_ledger ADD CONSTRAINT user_dimension_ledger_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_ledger_7988187_fkey') THEN
+        ALTER TABLE user_dimension_ledger ADD CONSTRAINT user_dimension_ledger_7988187_fkey FOREIGN KEY (user_account_state_type_id) REFERENCES user_account_state_type(id);
         END IF; END $$;
 
         DO $$ BEGIN
@@ -276,13 +286,13 @@ describe Masamune::Transform::DefineTable do
         CREATE TABLE IF NOT EXISTS user_dimension
         (
           id SERIAL,
-          cluster_type_id INTEGER NOT NULL REFERENCES cluster_type(id) DEFAULT default_cluster_type_id(),
-          user_account_state_type_id INTEGER NOT NULL REFERENCES user_account_state_type(id) DEFAULT default_user_account_state_type_id(),
+          cluster_type_id INTEGER NOT NULL DEFAULT default_cluster_type_id(),
+          user_account_state_type_id INTEGER NOT NULL DEFAULT default_user_account_state_type_id(),
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL,
           preferences HSTORE,
-          parent_id INTEGER REFERENCES user_dimension_ledger(id),
-          record_id INTEGER REFERENCES user_dimension_ledger(id),
+          parent_id INTEGER,
+          record_id INTEGER,
           start_at TIMESTAMP NOT NULL DEFAULT TO_TIMESTAMP(0),
           end_at TIMESTAMP,
           version INTEGER DEFAULT 1,
@@ -291,7 +301,27 @@ describe Masamune::Transform::DefineTable do
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_pkey') THEN
-        ALTER TABLE user_dimension ADD PRIMARY KEY (id);
+        ALTER TABLE user_dimension ADD PRIMARY KEY (cluster_type_id, id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_d6b9b38_fkey') THEN
+        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_7988187_fkey') THEN
+        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_7988187_fkey FOREIGN KEY (user_account_state_type_id) REFERENCES user_account_state_type(id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_e0538bc_fkey') THEN
+        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_e0538bc_fkey FOREIGN KEY (cluster_type_id, parent_id) REFERENCES user_dimension_ledger(cluster_type_id, id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_dimension_824002d_fkey') THEN
+        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_824002d_fkey FOREIGN KEY (cluster_type_id, record_id) REFERENCES user_dimension_ledger(cluster_type_id, id);
         END IF; END $$;
 
         DO $$ BEGIN

--- a/spec/masamune/transform/define_table.dimension_spec.rb
+++ b/spec/masamune/transform/define_table.dimension_spec.rb
@@ -175,8 +175,8 @@ describe Masamune::Transform::DefineTable do
     before do
       catalog.schema :postgres do
         dimension 'user', type: :two do
-          column 'tenant_id', index: true, natural_key: true
-          column 'user_id', index: true, natural_key: true
+          column 'tenant_id', natural_key: true
+          column 'user_id', natural_key: true
         end
       end
     end
@@ -207,28 +207,8 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
-        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e8701ad_index') THEN
-        CREATE INDEX user_dimension_e8701ad_index ON user_dimension (user_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_23563d3_index') THEN
-        CREATE INDEX user_dimension_23563d3_index ON user_dimension (start_at);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2c8e908_index') THEN
-        CREATE INDEX user_dimension_2c8e908_index ON user_dimension (end_at);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2af72f1_index') THEN
-        CREATE INDEX user_dimension_2af72f1_index ON user_dimension (version);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_index') THEN
+        CREATE UNIQUE INDEX user_dimension_e6c3d91_index ON user_dimension (tenant_id, user_id, start_at);
         END IF; END $$;
       EOS
     end
@@ -252,8 +232,8 @@ describe Masamune::Transform::DefineTable do
         dimension 'user', type: :four do
           references :cluster
           references :user_account_state
-          column 'tenant_id', index: true, natural_key: true
-          column 'user_id', index: true, natural_key: true
+          column 'tenant_id', natural_key: true
+          column 'user_id', natural_key: true
           column 'preferences', type: :key_value, null: true
         end
       end
@@ -284,33 +264,13 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_370d6dd_key') THEN
-        ALTER TABLE user_dimension_ledger ADD CONSTRAINT user_dimension_ledger_370d6dd_key UNIQUE(tenant_id, user_id, source_kind, source_uuid, start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_ff54dba_key') THEN
+        ALTER TABLE user_dimension_ledger ADD CONSTRAINT user_dimension_ledger_ff54dba_key UNIQUE(cluster_type_id, tenant_id, user_id, source_kind, source_uuid, start_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_d6b9b38_index') THEN
-        CREATE INDEX user_dimension_ledger_d6b9b38_index ON user_dimension_ledger (cluster_type_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_7988187_index') THEN
-        CREATE INDEX user_dimension_ledger_7988187_index ON user_dimension_ledger (user_account_state_type_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_3854361_index') THEN
-        CREATE INDEX user_dimension_ledger_3854361_index ON user_dimension_ledger (tenant_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_e8701ad_index') THEN
-        CREATE INDEX user_dimension_ledger_e8701ad_index ON user_dimension_ledger (user_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_23563d3_index') THEN
-        CREATE INDEX user_dimension_ledger_23563d3_index ON user_dimension_ledger (start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_ledger_370d6dd_index') THEN
+        CREATE INDEX user_dimension_ledger_370d6dd_index ON user_dimension_ledger (tenant_id, user_id, source_kind, source_uuid, start_at);
         END IF; END $$;
 
         CREATE TABLE IF NOT EXISTS user_dimension
@@ -335,43 +295,13 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_key') THEN
-        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_e6c3d91_key UNIQUE(tenant_id, user_id, start_at);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3fcebfa_key') THEN
+        ALTER TABLE user_dimension ADD CONSTRAINT user_dimension_3fcebfa_key UNIQUE(cluster_type_id, tenant_id, user_id, start_at);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_d6b9b38_index') THEN
-        CREATE INDEX user_dimension_d6b9b38_index ON user_dimension (cluster_type_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_7988187_index') THEN
-        CREATE INDEX user_dimension_7988187_index ON user_dimension (user_account_state_type_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_3854361_index') THEN
-        CREATE INDEX user_dimension_3854361_index ON user_dimension (tenant_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e8701ad_index') THEN
-        CREATE INDEX user_dimension_e8701ad_index ON user_dimension (user_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_23563d3_index') THEN
-        CREATE INDEX user_dimension_23563d3_index ON user_dimension (start_at);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2c8e908_index') THEN
-        CREATE INDEX user_dimension_2c8e908_index ON user_dimension (end_at);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_2af72f1_index') THEN
-        CREATE INDEX user_dimension_2af72f1_index ON user_dimension (version);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_dimension_e6c3d91_index') THEN
+        CREATE INDEX user_dimension_e6c3d91_index ON user_dimension (tenant_id, user_id, start_at);
         END IF; END $$;
       EOS
     end
@@ -388,8 +318,8 @@ describe Masamune::Transform::DefineTable do
 
         dimension 'user', type: :four do
           references :user_account_state
-          column 'tenant_id', index: true, natural_key: true
-          column 'user_id', index: true, natural_key: true
+          column 'tenant_id', natural_key: true
+          column 'user_id', natural_key: true
           column 'preferences', type: :key_value, null: true
         end
       end
@@ -413,12 +343,7 @@ describe Masamune::Transform::DefineTable do
           last_modified_at TIMESTAMP DEFAULT NOW()
         );
 
-        CREATE INDEX user_consolidated_forward_dimension_stage_7988187_index ON user_consolidated_forward_dimension_stage (user_account_state_type_id);
-        CREATE INDEX user_consolidated_forward_dimension_stage_3854361_index ON user_consolidated_forward_dimension_stage (tenant_id);
-        CREATE INDEX user_consolidated_forward_dimension_stage_e8701ad_index ON user_consolidated_forward_dimension_stage (user_id);
-        CREATE INDEX user_consolidated_forward_dimension_stage_23563d3_index ON user_consolidated_forward_dimension_stage (start_at);
-        CREATE INDEX user_consolidated_forward_dimension_stage_2c8e908_index ON user_consolidated_forward_dimension_stage (end_at);
-        CREATE INDEX user_consolidated_forward_dimension_stage_2af72f1_index ON user_consolidated_forward_dimension_stage (version);
+        CREATE INDEX user_consolidated_forward_dimension_stage_e6c3d91_index ON user_consolidated_forward_dimension_stage (tenant_id, user_id, start_at);
       EOS
     end
   end

--- a/spec/masamune/transform/define_table.fact_spec.rb
+++ b/spec/masamune/transform/define_table.fact_spec.rb
@@ -174,12 +174,18 @@ describe Masamune::Transform::DefineTable do
         COPY visits_file_fact_stage FROM 'output_3.csv' WITH (FORMAT 'csv', HEADER true);
 
         CREATE INDEX visits_file_fact_stage_964dac1_index ON visits_file_fact_stage (date_dimension_date_id);
-        CREATE INDEX visits_file_fact_stage_90fc13c_index ON visits_file_fact_stage (tenant_dimension_tenant_id);
-        CREATE INDEX visits_file_fact_stage_30f3cca_index ON visits_file_fact_stage (user_dimension_user_id);
-        CREATE INDEX visits_file_fact_stage_99c433b_index ON visits_file_fact_stage (user_agent_type_name);
-        CREATE INDEX visits_file_fact_stage_d5d236f_index ON visits_file_fact_stage (user_agent_type_version);
-        CREATE INDEX visits_file_fact_stage_5a187ed_index ON visits_file_fact_stage (feature_type_name);
         CREATE INDEX visits_file_fact_stage_6444ed3_index ON visits_file_fact_stage (time_key);
+        CREATE INDEX visits_file_fact_stage_90fc13c_index ON visits_file_fact_stage (tenant_dimension_tenant_id);
+        CREATE INDEX visits_file_fact_stage_5a187ed_index ON visits_file_fact_stage (feature_type_name);
+        CREATE INDEX visits_file_fact_stage_30f3cca_index ON visits_file_fact_stage (user_dimension_user_id);
+        CREATE INDEX visits_file_fact_stage_d5d236f_index ON visits_file_fact_stage (user_agent_type_version);
+        CREATE INDEX visits_file_fact_stage_99c433b_index ON visits_file_fact_stage (user_agent_type_name);
+        CREATE INDEX visits_file_fact_stage_766cbfa_index ON visits_file_fact_stage (user_agent_type_name, time_key);
+        CREATE INDEX visits_file_fact_stage_b0abfed_index ON visits_file_fact_stage (user_dimension_user_id, time_key);
+        CREATE INDEX visits_file_fact_stage_0fe2101_index ON visits_file_fact_stage (user_agent_type_version, time_key);
+        CREATE INDEX visits_file_fact_stage_69e4501_index ON visits_file_fact_stage (tenant_dimension_tenant_id, time_key);
+        CREATE INDEX visits_file_fact_stage_28291db_index ON visits_file_fact_stage (feature_type_name, time_key);
+        CREATE INDEX visits_file_fact_stage_8608ecc_index ON visits_file_fact_stage (date_dimension_date_id, time_key);
 
         ANALYZE visits_file_fact_stage;
       EOS

--- a/spec/masamune/transform/define_table.fact_spec.rb
+++ b/spec/masamune/transform/define_table.fact_spec.rb
@@ -33,10 +33,12 @@ describe Masamune::Transform::DefineTable do
       end
 
       dimension 'date', type: :date do
-        column 'date_id', type: :integer, unique: true, index: true, natural_key: true
+        column 'date_id', type: :integer, natural_key: true
       end
 
       dimension 'user_agent', type: :mini do
+        references :cluster
+
         column 'name', type: :string, unique: true, index: 'shared'
         column 'version', type: :string, unique: true, index: 'shared', default: 'Unknown'
         column 'description', type: :string, null: true, ignore: true
@@ -47,15 +49,21 @@ describe Masamune::Transform::DefineTable do
       end
 
       dimension 'tenant', type: :two do
-        column 'tenant_id', type: :integer, index: true, natural_key: true
+        references :cluster
+
+        column 'tenant_id', type: :integer, natural_key: true
       end
 
       dimension 'user', type: :two do
-        column 'tenant_id', type: :integer, index: true, natural_key: true
-        column 'user_id', type: :integer, index: true, natural_key: true
+        references :cluster
+
+        column 'tenant_id', type: :integer, natural_key: true
+        column 'user_id', type: :integer, natural_key: true
       end
 
       dimension 'group', type: :two do
+        references :cluster
+
         column 'group_id', type: :integer, natural_key: true
       end
 
@@ -125,57 +133,17 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS visits_fact
         (
-          cluster_type_id INTEGER NOT NULL REFERENCES cluster_type(id) DEFAULT default_cluster_type_id(),
-          date_dimension_id INTEGER NOT NULL REFERENCES date_dimension(id),
-          tenant_dimension_id INTEGER NOT NULL REFERENCES tenant_dimension(id),
-          user_dimension_id INTEGER NOT NULL REFERENCES user_dimension(id),
+          cluster_type_id INTEGER NOT NULL DEFAULT default_cluster_type_id(),
+          date_dimension_id INTEGER NOT NULL,
+          tenant_dimension_id INTEGER NOT NULL,
+          user_dimension_id INTEGER NOT NULL,
           group_dimension_id INTEGER[] NOT NULL,
-          user_agent_type_id INTEGER NOT NULL REFERENCES user_agent_type(id),
-          feature_type_id INTEGER NOT NULL REFERENCES feature_type(id),
+          user_agent_type_id INTEGER NOT NULL,
+          feature_type_id INTEGER NOT NULL,
           total INTEGER NOT NULL,
           time_key INTEGER NOT NULL,
           last_modified_at TIMESTAMP NOT NULL DEFAULT NOW()
         );
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_d6b9b38_index') THEN
-        CREATE INDEX visits_fact_d6b9b38_index ON visits_fact (cluster_type_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_0a531a8_index') THEN
-        CREATE INDEX visits_fact_0a531a8_index ON visits_fact (date_dimension_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_d3950d9_index') THEN
-        CREATE INDEX visits_fact_d3950d9_index ON visits_fact (tenant_dimension_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_39f0fdd_index') THEN
-        CREATE INDEX visits_fact_39f0fdd_index ON visits_fact (user_dimension_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_e0d2a9e_index') THEN
-        CREATE INDEX visits_fact_e0d2a9e_index ON visits_fact (group_dimension_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_d8b1c3e_index') THEN
-        CREATE INDEX visits_fact_d8b1c3e_index ON visits_fact (user_agent_type_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_33b68fd_index') THEN
-        CREATE INDEX visits_fact_33b68fd_index ON visits_fact (feature_type_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_6444ed3_index') THEN
-        CREATE INDEX visits_fact_6444ed3_index ON visits_fact (time_key);
-        END IF; END $$;
       EOS
     end
   end
@@ -256,16 +224,6 @@ describe Masamune::Transform::DefineTable do
           time_key INTEGER NOT NULL,
           last_modified_at TIMESTAMP NOT NULL DEFAULT NOW()
         );
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_2a6313d_index') THEN
-        CREATE INDEX visits_fact_2a6313d_index ON visits_fact (message_kind_type_id);
-        END IF; END $$;
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'visits_fact_6444ed3_index') THEN
-        CREATE INDEX visits_fact_6444ed3_index ON visits_fact (time_key);
-        END IF; END $$;
       EOS
     end
   end

--- a/spec/masamune/transform/define_table.fact_spec.rb
+++ b/spec/masamune/transform/define_table.fact_spec.rb
@@ -174,18 +174,18 @@ describe Masamune::Transform::DefineTable do
         COPY visits_file_fact_stage FROM 'output_3.csv' WITH (FORMAT 'csv', HEADER true);
 
         CREATE INDEX visits_file_fact_stage_964dac1_index ON visits_file_fact_stage (date_dimension_date_id);
-        CREATE INDEX visits_file_fact_stage_6444ed3_index ON visits_file_fact_stage (time_key);
-        CREATE INDEX visits_file_fact_stage_90fc13c_index ON visits_file_fact_stage (tenant_dimension_tenant_id);
         CREATE INDEX visits_file_fact_stage_5a187ed_index ON visits_file_fact_stage (feature_type_name);
-        CREATE INDEX visits_file_fact_stage_30f3cca_index ON visits_file_fact_stage (user_dimension_user_id);
-        CREATE INDEX visits_file_fact_stage_d5d236f_index ON visits_file_fact_stage (user_agent_type_version);
+        CREATE INDEX visits_file_fact_stage_90fc13c_index ON visits_file_fact_stage (tenant_dimension_tenant_id);
+        CREATE INDEX visits_file_fact_stage_6444ed3_index ON visits_file_fact_stage (time_key);
         CREATE INDEX visits_file_fact_stage_99c433b_index ON visits_file_fact_stage (user_agent_type_name);
-        CREATE INDEX visits_file_fact_stage_766cbfa_index ON visits_file_fact_stage (user_agent_type_name, time_key);
-        CREATE INDEX visits_file_fact_stage_b0abfed_index ON visits_file_fact_stage (user_dimension_user_id, time_key);
-        CREATE INDEX visits_file_fact_stage_0fe2101_index ON visits_file_fact_stage (user_agent_type_version, time_key);
-        CREATE INDEX visits_file_fact_stage_69e4501_index ON visits_file_fact_stage (tenant_dimension_tenant_id, time_key);
-        CREATE INDEX visits_file_fact_stage_28291db_index ON visits_file_fact_stage (feature_type_name, time_key);
+        CREATE INDEX visits_file_fact_stage_d5d236f_index ON visits_file_fact_stage (user_agent_type_version);
+        CREATE INDEX visits_file_fact_stage_30f3cca_index ON visits_file_fact_stage (user_dimension_user_id);
         CREATE INDEX visits_file_fact_stage_8608ecc_index ON visits_file_fact_stage (date_dimension_date_id, time_key);
+        CREATE INDEX visits_file_fact_stage_28291db_index ON visits_file_fact_stage (feature_type_name, time_key);
+        CREATE INDEX visits_file_fact_stage_69e4501_index ON visits_file_fact_stage (tenant_dimension_tenant_id, time_key);
+        CREATE INDEX visits_file_fact_stage_766cbfa_index ON visits_file_fact_stage (user_agent_type_name, time_key);
+        CREATE INDEX visits_file_fact_stage_0fe2101_index ON visits_file_fact_stage (user_agent_type_version, time_key);
+        CREATE INDEX visits_file_fact_stage_b0abfed_index ON visits_file_fact_stage (user_dimension_user_id, time_key);
 
         ANALYZE visits_file_fact_stage;
       EOS

--- a/spec/masamune/transform/define_table.table_spec.rb
+++ b/spec/masamune/transform/define_table.table_spec.rb
@@ -285,13 +285,13 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_index') THEN
-        CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
+        CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
-        CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_index') THEN
+        CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
         END IF; END $$;
 
         DO $$ BEGIN

--- a/spec/masamune/transform/define_table.table_spec.rb
+++ b/spec/masamune/transform/define_table.table_spec.rb
@@ -221,6 +221,16 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
+        CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_index') THEN
+        CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_index') THEN
         CREATE INDEX user_table_e0e4295_index ON user_table (tenant_id, user_id);
         END IF; END $$;
@@ -267,6 +277,21 @@ describe Masamune::Transform::DefineTable do
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_9f1c0d7_key') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_9f1c0d7_key UNIQUE(cluster_table_id, tenant_id, user_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_8923fdb_index') THEN
+        CREATE INDEX user_table_8923fdb_index ON user_table (cluster_table_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_index') THEN
+        CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
+        CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
         END IF; END $$;
 
         DO $$ BEGIN
@@ -329,6 +354,16 @@ describe Masamune::Transform::DefineTable do
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_9f1c0d7_key') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_9f1c0d7_key UNIQUE(cluster_table_id, tenant_id, user_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
+        CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_index') THEN
+        CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
         END IF; END $$;
 
         DO $$ BEGIN
@@ -514,6 +549,16 @@ describe Masamune::Transform::DefineTable do
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_key') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_e0e4295_key UNIQUE(tenant_id, user_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
+        CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
+        END IF; END $$;
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_index') THEN
+        CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
         END IF; END $$;
 
         DO $$ BEGIN

--- a/spec/masamune/transform/define_table.table_spec.rb
+++ b/spec/masamune/transform/define_table.table_spec.rb
@@ -41,10 +41,15 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
       EOS
     end
   end
@@ -65,10 +70,15 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
@@ -99,10 +109,15 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
@@ -138,10 +153,15 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e8701ad_key') THEN
@@ -178,11 +198,16 @@ describe Masamune::Transform::DefineTable do
 
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL,
           state USER_STATE_TYPE NOT NULL DEFAULT 'active'::USER_STATE_TYPE
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
       EOS
     end
   end
@@ -203,9 +228,14 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          identifier UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+          identifier UUID DEFAULT uuid_generate_v4(),
           name VARCHAR NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (identifier);
+        END IF; END $$;
       EOS
     end
   end
@@ -228,10 +258,15 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           name VARCHAR NOT NULL,
           description VARCHAR NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         INSERT INTO user_table (name, description)
         SELECT 'registered', 'Registered'
@@ -262,10 +297,15 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_key') THEN
@@ -298,10 +338,15 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_e0e4295_key') THEN
@@ -365,10 +410,15 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           user_account_state_table_id INTEGER NOT NULL REFERENCES user_account_state_table(id) DEFAULT default_user_account_state_table_id(),
           name VARCHAR NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_bd2027e_index') THEN
@@ -401,11 +451,16 @@ describe Masamune::Transform::DefineTable do
       is_expected.to eq <<-EOS.strip_heredoc
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id SERIAL PRIMARY KEY,
+          id SERIAL,
           user_account_state_table_id INTEGER NOT NULL REFERENCES user_account_state_table(id) DEFAULT default_user_account_state_table_id(),
           hr_user_account_state_table_id INTEGER REFERENCES user_account_state_table(id),
           name VARCHAR NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_bd2027e_index') THEN
@@ -514,10 +569,15 @@ describe Masamune::Transform::DefineTable do
 
         CREATE TABLE IF NOT EXISTS user_table
         (
-          id INTEGER PRIMARY KEY DEFAULT nextval('user_table_id_seq'),
+          id INTEGER DEFAULT nextval('user_table_id_seq'),
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
+
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
 
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 WHERE sequence_owner('user_table_id_seq') = 'user_table.id') THEN

--- a/spec/masamune/transform/define_table.table_spec.rb
+++ b/spec/masamune/transform/define_table.table_spec.rb
@@ -211,7 +211,7 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_table_8923fdb_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_table_8923fdb_fkey') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_8923fdb_fkey FOREIGN KEY (cluster_table_id) REFERENCES cluster_table(id);
         END IF; END $$;
 
@@ -260,7 +260,7 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_table_8923fdb_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_table_8923fdb_fkey') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_8923fdb_fkey FOREIGN KEY (cluster_table_id) REFERENCES cluster_table(id);
         END IF; END $$;
 
@@ -317,12 +317,12 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_table_8923fdb_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_table_8923fdb_fkey') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_8923fdb_fkey FOREIGN KEY (cluster_table_id) REFERENCES cluster_table(id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_table_9000538_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_table_9000538_fkey') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_9000538_fkey FOREIGN KEY (cluster_table_id, department_table_id) REFERENCES department_table(cluster_table_id, id);
         END IF; END $$;
 
@@ -589,7 +589,7 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_table_bd2027e_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_table_bd2027e_fkey') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_bd2027e_fkey FOREIGN KEY (user_account_state_table_id) REFERENCES user_account_state_table(id);
         END IF; END $$;
       EOS
@@ -631,12 +631,12 @@ describe Masamune::Transform::DefineTable do
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_table_bd2027e_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_table_bd2027e_fkey') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_bd2027e_fkey FOREIGN KEY (user_account_state_table_id) REFERENCES user_account_state_table(id);
         END IF; END $$;
 
         DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname= 'user_table_074da4a_fkey') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_table_074da4a_fkey') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_074da4a_fkey FOREIGN KEY (hr_user_account_state_table_id) REFERENCES user_account_state_table(id);
         END IF; END $$;
       EOS

--- a/spec/masamune/transform/rollup_fact_spec.rb
+++ b/spec/masamune/transform/rollup_fact_spec.rb
@@ -145,11 +145,11 @@ describe Masamune::Transform::RollupFact do
 
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d6b9b38_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_0a531a8_index;
-        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d3950d9_index;
-        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_39f0fdd_index;
-        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d8b1c3e_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_33b68fd_index;
+        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d3950d9_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_6444ed3_index;
+        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d8b1c3e_index;
+        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_39f0fdd_index;
 
         ALTER TABLE visits_hourly_fact_y2014m08 RENAME TO visits_hourly_fact_y2014m08_stage_tmp;
         ALTER TABLE visits_hourly_fact_y2014m08_stage RENAME TO visits_hourly_fact_y2014m08;
@@ -165,11 +165,11 @@ describe Masamune::Transform::RollupFact do
 
         CREATE INDEX visits_hourly_fact_y2014m08_d6b9b38_index ON visits_hourly_fact_y2014m08 (cluster_type_id);
         CREATE INDEX visits_hourly_fact_y2014m08_0a531a8_index ON visits_hourly_fact_y2014m08 (date_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_d3950d9_index ON visits_hourly_fact_y2014m08 (tenant_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_39f0fdd_index ON visits_hourly_fact_y2014m08 (user_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_d8b1c3e_index ON visits_hourly_fact_y2014m08 (user_agent_type_id);
         CREATE INDEX visits_hourly_fact_y2014m08_33b68fd_index ON visits_hourly_fact_y2014m08 (feature_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_d3950d9_index ON visits_hourly_fact_y2014m08 (tenant_dimension_id);
         CREATE INDEX visits_hourly_fact_y2014m08_6444ed3_index ON visits_hourly_fact_y2014m08 (time_key);
+        CREATE INDEX visits_hourly_fact_y2014m08_d8b1c3e_index ON visits_hourly_fact_y2014m08 (user_agent_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_39f0fdd_index ON visits_hourly_fact_y2014m08 (user_dimension_id);
 
         ANALYZE visits_hourly_fact_y2014m08;
 
@@ -246,11 +246,11 @@ describe Masamune::Transform::RollupFact do
 
         DROP INDEX IF EXISTS visits_daily_fact_y2014m08_d6b9b38_index;
         DROP INDEX IF EXISTS visits_daily_fact_y2014m08_0a531a8_index;
-        DROP INDEX IF EXISTS visits_daily_fact_y2014m08_d3950d9_index;
-        DROP INDEX IF EXISTS visits_daily_fact_y2014m08_39f0fdd_index;
-        DROP INDEX IF EXISTS visits_daily_fact_y2014m08_d8b1c3e_index;
         DROP INDEX IF EXISTS visits_daily_fact_y2014m08_33b68fd_index;
+        DROP INDEX IF EXISTS visits_daily_fact_y2014m08_d3950d9_index;
         DROP INDEX IF EXISTS visits_daily_fact_y2014m08_6444ed3_index;
+        DROP INDEX IF EXISTS visits_daily_fact_y2014m08_d8b1c3e_index;
+        DROP INDEX IF EXISTS visits_daily_fact_y2014m08_39f0fdd_index;
 
         ALTER TABLE visits_daily_fact_y2014m08 RENAME TO visits_daily_fact_y2014m08_stage_tmp;
         ALTER TABLE visits_daily_fact_y2014m08_stage RENAME TO visits_daily_fact_y2014m08;
@@ -266,11 +266,11 @@ describe Masamune::Transform::RollupFact do
 
         CREATE INDEX visits_daily_fact_y2014m08_d6b9b38_index ON visits_daily_fact_y2014m08 (cluster_type_id);
         CREATE INDEX visits_daily_fact_y2014m08_0a531a8_index ON visits_daily_fact_y2014m08 (date_dimension_id);
-        CREATE INDEX visits_daily_fact_y2014m08_d3950d9_index ON visits_daily_fact_y2014m08 (tenant_dimension_id);
-        CREATE INDEX visits_daily_fact_y2014m08_39f0fdd_index ON visits_daily_fact_y2014m08 (user_dimension_id);
-        CREATE INDEX visits_daily_fact_y2014m08_d8b1c3e_index ON visits_daily_fact_y2014m08 (user_agent_type_id);
         CREATE INDEX visits_daily_fact_y2014m08_33b68fd_index ON visits_daily_fact_y2014m08 (feature_type_id);
+        CREATE INDEX visits_daily_fact_y2014m08_d3950d9_index ON visits_daily_fact_y2014m08 (tenant_dimension_id);
         CREATE INDEX visits_daily_fact_y2014m08_6444ed3_index ON visits_daily_fact_y2014m08 (time_key);
+        CREATE INDEX visits_daily_fact_y2014m08_d8b1c3e_index ON visits_daily_fact_y2014m08 (user_agent_type_id);
+        CREATE INDEX visits_daily_fact_y2014m08_39f0fdd_index ON visits_daily_fact_y2014m08 (user_dimension_id);
 
         ANALYZE visits_daily_fact_y2014m08;
 
@@ -347,11 +347,11 @@ describe Masamune::Transform::RollupFact do
 
         DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_d6b9b38_index;
         DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_0a531a8_index;
-        DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_d3950d9_index;
-        DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_39f0fdd_index;
-        DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_d8b1c3e_index;
         DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_33b68fd_index;
+        DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_d3950d9_index;
         DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_6444ed3_index;
+        DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_d8b1c3e_index;
+        DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_39f0fdd_index;
 
         ALTER TABLE visits_monthly_fact_y2014m08 RENAME TO visits_monthly_fact_y2014m08_stage_tmp;
         ALTER TABLE visits_monthly_fact_y2014m08_stage RENAME TO visits_monthly_fact_y2014m08;
@@ -367,11 +367,11 @@ describe Masamune::Transform::RollupFact do
 
         CREATE INDEX visits_monthly_fact_y2014m08_d6b9b38_index ON visits_monthly_fact_y2014m08 (cluster_type_id);
         CREATE INDEX visits_monthly_fact_y2014m08_0a531a8_index ON visits_monthly_fact_y2014m08 (date_dimension_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_d3950d9_index ON visits_monthly_fact_y2014m08 (tenant_dimension_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_39f0fdd_index ON visits_monthly_fact_y2014m08 (user_dimension_id);
-        CREATE INDEX visits_monthly_fact_y2014m08_d8b1c3e_index ON visits_monthly_fact_y2014m08 (user_agent_type_id);
         CREATE INDEX visits_monthly_fact_y2014m08_33b68fd_index ON visits_monthly_fact_y2014m08 (feature_type_id);
+        CREATE INDEX visits_monthly_fact_y2014m08_d3950d9_index ON visits_monthly_fact_y2014m08 (tenant_dimension_id);
         CREATE INDEX visits_monthly_fact_y2014m08_6444ed3_index ON visits_monthly_fact_y2014m08 (time_key);
+        CREATE INDEX visits_monthly_fact_y2014m08_d8b1c3e_index ON visits_monthly_fact_y2014m08 (user_agent_type_id);
+        CREATE INDEX visits_monthly_fact_y2014m08_39f0fdd_index ON visits_monthly_fact_y2014m08 (user_dimension_id);
 
         ANALYZE visits_monthly_fact_y2014m08;
 

--- a/spec/masamune/transform/rollup_fact_spec.rb
+++ b/spec/masamune/transform/rollup_fact_spec.rb
@@ -136,12 +136,12 @@ describe Masamune::Transform::RollupFact do
         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
         ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_time_key_check;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_cluster_type_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_date_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_tenant_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_user_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_user_agent_type_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_feature_type_id_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_d6b9b38_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_0a531a8_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_d3950d9_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_39f0fdd_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_d8b1c3e_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_33b68fd_fkey CASCADE;
 
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d6b9b38_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_0a531a8_index;
@@ -156,12 +156,12 @@ describe Masamune::Transform::RollupFact do
 
         ALTER TABLE visits_hourly_fact_y2014m08 INHERIT visits_hourly_fact;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_0a531a8_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_d3950d9_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_39f0fdd_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_d8b1c3e_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_33b68fd_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
 
         CREATE INDEX visits_hourly_fact_y2014m08_d6b9b38_index ON visits_hourly_fact_y2014m08 (cluster_type_id);
         CREATE INDEX visits_hourly_fact_y2014m08_0a531a8_index ON visits_hourly_fact_y2014m08 (date_dimension_id);
@@ -237,12 +237,12 @@ describe Masamune::Transform::RollupFact do
         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
         ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_time_key_check;
-        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_cluster_type_id_fkey CASCADE;
-        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_date_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_tenant_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_user_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_user_agent_type_id_fkey CASCADE;
-        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_feature_type_id_fkey CASCADE;
+        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_d6b9b38_fkey CASCADE;
+        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_0a531a8_fkey CASCADE;
+        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_d3950d9_fkey CASCADE;
+        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_39f0fdd_fkey CASCADE;
+        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_d8b1c3e_fkey CASCADE;
+        ALTER TABLE visits_daily_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_daily_fact_y2014m08_33b68fd_fkey CASCADE;
 
         DROP INDEX IF EXISTS visits_daily_fact_y2014m08_d6b9b38_index;
         DROP INDEX IF EXISTS visits_daily_fact_y2014m08_0a531a8_index;
@@ -257,12 +257,12 @@ describe Masamune::Transform::RollupFact do
 
         ALTER TABLE visits_daily_fact_y2014m08 INHERIT visits_daily_fact;
         ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
-        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_0a531a8_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_d3950d9_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_39f0fdd_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_d8b1c3e_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_33b68fd_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
 
         CREATE INDEX visits_daily_fact_y2014m08_d6b9b38_index ON visits_daily_fact_y2014m08 (cluster_type_id);
         CREATE INDEX visits_daily_fact_y2014m08_0a531a8_index ON visits_daily_fact_y2014m08 (date_dimension_id);
@@ -338,12 +338,12 @@ describe Masamune::Transform::RollupFact do
         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
         ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_time_key_check;
-        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_cluster_type_id_fkey CASCADE;
-        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_date_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_tenant_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_user_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_user_agent_type_id_fkey CASCADE;
-        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_feature_type_id_fkey CASCADE;
+        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_d6b9b38_fkey CASCADE;
+        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_0a531a8_fkey CASCADE;
+        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_d3950d9_fkey CASCADE;
+        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_39f0fdd_fkey CASCADE;
+        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_d8b1c3e_fkey CASCADE;
+        ALTER TABLE visits_monthly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_monthly_fact_y2014m08_33b68fd_fkey CASCADE;
 
         DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_d6b9b38_index;
         DROP INDEX IF EXISTS visits_monthly_fact_y2014m08_0a531a8_index;
@@ -358,12 +358,12 @@ describe Masamune::Transform::RollupFact do
 
         ALTER TABLE visits_monthly_fact_y2014m08 INHERIT visits_monthly_fact;
         ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
-        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_0a531a8_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_d3950d9_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_39f0fdd_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_d8b1c3e_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_33b68fd_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
 
         CREATE INDEX visits_monthly_fact_y2014m08_d6b9b38_index ON visits_monthly_fact_y2014m08 (cluster_type_id);
         CREATE INDEX visits_monthly_fact_y2014m08_0a531a8_index ON visits_monthly_fact_y2014m08 (date_dimension_id);

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -35,10 +35,12 @@ describe Masamune::Transform::StageFact do
       end
 
       dimension 'date', type: :date do
-        column 'date_id', type: :integer, unique: true, index: true, natural_key: true
+        column 'date_id', type: :integer, natural_key: true
       end
 
       dimension 'user_agent', type: :mini do
+        references :cluster
+
         column 'name', type: :string, unique: true, index: 'shared'
         column 'version', type: :string, unique: true, index: 'shared', default: 'Unknown'
         column 'mobile', type: :boolean, unique: true, index: 'shared', default: false
@@ -50,16 +52,22 @@ describe Masamune::Transform::StageFact do
       end
 
       dimension 'tenant', type: :two do
-        column 'tenant_id', type: :integer, index: true, natural_key: true
+        references :cluster
+
+        column 'tenant_id', type: :integer, natural_key: true
       end
 
       dimension 'user', type: :two do
-        column 'tenant_id', type: :integer, index: true, natural_key: true
-        column 'user_id', type: :integer, index: true, natural_key: true
+        references :cluster
+
+        column 'tenant_id', type: :integer, natural_key: true
+        column 'user_id', type: :integer, natural_key: true
       end
 
       dimension 'group', type: :two do
-        column 'group_id', type: :integer, index: true, natural_key: true
+        references :cluster
+
+        column 'group_id', type: :integer, natural_key: true
         column 'group_mode', type: :enum, sub_type: 'group_mode', values: %(missing public private), index: true, natural_key: true, default: 'missing'
         row group_id: -1, group_mode: 'missing', attributes: {id: :missing}
       end
@@ -167,13 +175,13 @@ describe Masamune::Transform::StageFact do
         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
         ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_time_key_check;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_cluster_type_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_date_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_tenant_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_user_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_group_dimension_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_user_agent_type_id_fkey CASCADE;
-        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_feature_type_id_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_d6b9b38_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_0a531a8_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_ff74c56_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_1aeb6c0_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_b4cc377_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_13f0010_fkey CASCADE;
+        ALTER TABLE visits_hourly_fact_y2014m08 DROP CONSTRAINT IF EXISTS visits_hourly_fact_y2014m08_33b68fd_fkey CASCADE;
 
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d6b9b38_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_0a531a8_index;
@@ -190,13 +198,13 @@ describe Masamune::Transform::StageFact do
 
         ALTER TABLE visits_hourly_fact_y2014m08 INHERIT visits_hourly_fact;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_cluster_type_id_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_date_dimension_id_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_tenant_dimension_id_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_user_dimension_id_fkey FOREIGN KEY (user_dimension_id) REFERENCES user_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_group_dimension_id_fkey FOREIGN KEY (group_dimension_id) REFERENCES group_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_user_agent_type_id_fkey FOREIGN KEY (user_agent_type_id) REFERENCES user_agent_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
-        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_feature_type_id_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_0a531a8_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_ff74c56_fkey FOREIGN KEY (cluster_type_id, tenant_dimension_id) REFERENCES tenant_dimension(cluster_type_id, id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_1aeb6c0_fkey FOREIGN KEY (cluster_type_id, user_dimension_id) REFERENCES user_dimension(cluster_type_id, id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_b4cc377_fkey FOREIGN KEY (cluster_type_id, group_dimension_id) REFERENCES group_dimension(cluster_type_id, id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_13f0010_fkey FOREIGN KEY (cluster_type_id, user_agent_type_id) REFERENCES user_agent_type(cluster_type_id, id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
+        ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_33b68fd_fkey FOREIGN KEY (feature_type_id) REFERENCES feature_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
 
         CREATE INDEX visits_hourly_fact_y2014m08_d6b9b38_index ON visits_hourly_fact_y2014m08 (cluster_type_id);
         CREATE INDEX visits_hourly_fact_y2014m08_0a531a8_index ON visits_hourly_fact_y2014m08 (date_dimension_id);

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -185,13 +185,13 @@ describe Masamune::Transform::StageFact do
 
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d6b9b38_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_0a531a8_index;
-        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d3950d9_index;
-        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_39f0fdd_index;
-        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_e0d2a9e_index;
-        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d8b1c3e_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_33b68fd_index;
+        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_e0d2a9e_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_422efee_index;
+        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d3950d9_index;
         DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_6444ed3_index;
+        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_d8b1c3e_index;
+        DROP INDEX IF EXISTS visits_hourly_fact_y2014m08_39f0fdd_index;
 
         ALTER TABLE visits_hourly_fact_y2014m08 RENAME TO visits_hourly_fact_y2014m08_stage_tmp;
         ALTER TABLE visits_hourly_fact_y2014m08_stage RENAME TO visits_hourly_fact_y2014m08;
@@ -208,13 +208,13 @@ describe Masamune::Transform::StageFact do
 
         CREATE INDEX visits_hourly_fact_y2014m08_d6b9b38_index ON visits_hourly_fact_y2014m08 (cluster_type_id);
         CREATE INDEX visits_hourly_fact_y2014m08_0a531a8_index ON visits_hourly_fact_y2014m08 (date_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_d3950d9_index ON visits_hourly_fact_y2014m08 (tenant_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_39f0fdd_index ON visits_hourly_fact_y2014m08 (user_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_e0d2a9e_index ON visits_hourly_fact_y2014m08 (group_dimension_id);
-        CREATE INDEX visits_hourly_fact_y2014m08_d8b1c3e_index ON visits_hourly_fact_y2014m08 (user_agent_type_id);
         CREATE INDEX visits_hourly_fact_y2014m08_33b68fd_index ON visits_hourly_fact_y2014m08 (feature_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_e0d2a9e_index ON visits_hourly_fact_y2014m08 (group_dimension_id);
         CREATE INDEX visits_hourly_fact_y2014m08_422efee_index ON visits_hourly_fact_y2014m08 (session_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_d3950d9_index ON visits_hourly_fact_y2014m08 (tenant_dimension_id);
         CREATE INDEX visits_hourly_fact_y2014m08_6444ed3_index ON visits_hourly_fact_y2014m08 (time_key);
+        CREATE INDEX visits_hourly_fact_y2014m08_d8b1c3e_index ON visits_hourly_fact_y2014m08 (user_agent_type_id);
+        CREATE INDEX visits_hourly_fact_y2014m08_39f0fdd_index ON visits_hourly_fact_y2014m08 (user_dimension_id);
 
         ANALYZE visits_hourly_fact_y2014m08;
 


### PR DESCRIPTION
- Add `auto` reference columns to compound primary key (used for sharding tables across clusters)
- Separate `masamune-dump` from `masamune-shell`
  - add options to dump schema without index, foreign_keys, and uniqueness constraints
- Ensure `natural_key` dimension columns have a compound index where appropriate
- Add `time_key` compound index to fact stage tables
- Remove `FOREIGN KEY` constraints for fact tables (added to partition tables after `load_fact`)
- Remove `INDEX` declarations for fact tables (added to partition tables after `load_fact`)
- Allow packaged templates to be called outside of library