### PR TITLE
Improve dump task

### DIFF
--- a/lib/masamune/actions/date_parse.rb
+++ b/lib/masamune/actions/date_parse.rb
@@ -30,7 +30,7 @@ module Masamune::Actions
     def parse_datetime_type(key)
       value = options[key]
       Chronic.parse(value).tap do |datetime_value|
-        console("Using '#{datetime_value}' for --#{key}") if value != datetime_value
+        logger.debug("Using '#{datetime_value}' for --#{key}") if value != datetime_value
       end or raise Thor::MalformattedArgumentError, "Expected date time value for '--#{key}'; got #{value}"
     end
 

--- a/lib/masamune/data_plan/rule.rb
+++ b/lib/masamune/data_plan/rule.rb
@@ -109,9 +109,18 @@ class Masamune::DataPlan::Rule
     matched_pattern.present? && matched_pattern[:rest].blank?
   end
 
-  def bind_date(input_date)
-    output_date = tz.utc_to_local(input_date)
-    Masamune::DataPlan::Elem.new(self, output_date, options_for_elem)
+  def bind_date_or_time(input = nil)
+    input_time = 
+    case input
+    when Time, DateTime
+      input
+    when Date
+      input.to_time
+    else
+      raise ArgumentError, "Cannot bind_date_or_time with type #{input.class}"
+    end
+    output_time = tz.utc_to_local(input_time)
+    Masamune::DataPlan::Elem.new(self, output_time, options_for_elem)
   end
 
   def bind_input(input)
@@ -123,12 +132,12 @@ class Masamune::DataPlan::Rule
   end
 
   def unify(elem, rule)
-    rule.bind_date(elem.start_time)
+    rule.bind_date_or_time(elem.start_time)
   end
 
   def generate(start_time, stop_time)
     return Set.new(to_enum(:generate, start_time, stop_time)) unless block_given?
-    instance = bind_date(start_time)
+    instance = bind_date_or_time(start_time)
 
     begin
       yield instance

--- a/lib/masamune/data_plan/rule.rb
+++ b/lib/masamune/data_plan/rule.rb
@@ -110,7 +110,7 @@ class Masamune::DataPlan::Rule
   end
 
   def bind_date_or_time(input = nil)
-    input_time = 
+    input_time =
     case input
     when Time, DateTime
       input

--- a/lib/masamune/schema/fact.rb
+++ b/lib/masamune/schema/fact.rb
@@ -88,8 +88,7 @@ module Masamune::Schema
     def partition_table(date = nil)
       return unless partition
       return unless date
-      # TODO increase robustness of bind_date
-      partition_range = partition_rule.bind_date(date)
+      partition_range = partition_rule.bind_date_or_time(date)
       @partition_tables ||= {}
       @partition_tables[partition_range] ||= self.class.new(id: @id, store: store, columns: partition_table_columns, parent: self, range: partition_range, grain: grain, inherit: true)
     end
@@ -99,7 +98,7 @@ module Masamune::Schema
       return unless start_date && stop_date
       (start_date .. stop_date).each do |date|
         next unless date.day == 1
-        yield partition_table(date.to_time)
+        yield partition_table(date)
       end 
     end
 

--- a/lib/masamune/schema/fact.rb
+++ b/lib/masamune/schema/fact.rb
@@ -106,7 +106,7 @@ module Masamune::Schema
       columns.select { |_, column| column.measure }
     end
 
-    def constraints
+    def inheritance_constraints
       return unless range
       "CHECK (time_key >= #{range.start_time.to_i} AND time_key < #{range.stop_time.to_i})"
     end

--- a/lib/masamune/schema/fact.rb
+++ b/lib/masamune/schema/fact.rb
@@ -99,7 +99,7 @@ module Masamune::Schema
       (start_date .. stop_date).each do |date|
         next unless date.day == 1
         yield partition_table(date)
-      end 
+      end
     end
 
     def measures

--- a/lib/masamune/schema/fact.rb
+++ b/lib/masamune/schema/fact.rb
@@ -85,10 +85,22 @@ module Masamune::Schema
       end
     end
 
-    def partition_table(date)
+    def partition_table(date = nil)
+      return unless partition
+      return unless date
+      # TODO increase robustness of bind_date
       partition_range = partition_rule.bind_date(date)
       @partition_tables ||= {}
       @partition_tables[partition_range] ||= self.class.new(id: @id, store: store, columns: partition_table_columns, parent: self, range: partition_range, grain: grain, inherit: true)
+    end
+
+    def partition_tables(start_date = nil, stop_date = nil)
+      return unless partition
+      return unless start_date && stop_date
+      (start_date .. stop_date).each do |date|
+        next unless date.day == 1
+        yield partition_table(date.to_time)
+      end 
     end
 
     def measures

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -56,6 +56,10 @@ module Masamune::Schema
       @children = Set.new
     end
 
+    def inspect
+      name
+    end
+
     def id=(id)
       @id = id.to_sym
     end

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -56,10 +56,6 @@ module Masamune::Schema
       @children = Set.new
     end
 
-    def inspect
-      name
-    end
-
     def id=(id)
       @id = id.to_sym
     end

--- a/lib/masamune/tasks/dump_thor.rb
+++ b/lib/masamune/tasks/dump_thor.rb
@@ -26,6 +26,7 @@ require 'thor'
 module Masamune::Tasks
   class DumpThor < Thor
     include Masamune::Thor
+    include Masamune::Actions::DateParse
     include Masamune::Transform::DefineSchema
 
     # FIXME need to add an unnecessary namespace until this issue is fixed:
@@ -47,10 +48,18 @@ module Masamune::Tasks
     def print_catalog
       case options[:type]
       when 'psql'
-        puts define_schema(catalog, :postgres, options[:section].to_sym)
+        puts define_schema(catalog, :postgres, define_schema_options)
       when 'hql'
-        puts define_schema(catalog, :hive, options[:section].to_sym)
+        puts define_schema(catalog, :hive, define_schema_options)
       end
+    end
+
+    def define_schema_options
+      {
+        section: options[:section].to_sym,
+        start_date: start_date,
+        stop_date: stop_date
+      }.reject { |_, v| v.blank? }
     end
   end
 end

--- a/lib/masamune/tasks/dump_thor.rb
+++ b/lib/masamune/tasks/dump_thor.rb
@@ -35,9 +35,7 @@ module Masamune::Tasks
 
     desc 'dump', 'Dump schema'
     method_option :type, :enum => ['psql', 'hql'], :desc => 'Schema type', :default => 'psql'
-    method_option :with_index, :type => :boolean, :desc => 'Dump schema with indexes', :default => true
-    method_option :with_foreign_key, :type => :boolean, :desc => 'Dump schema with foreign key constraints', :default => true
-    method_option :with_unique_constraint, :type => :boolean, :desc => 'Dump schema with uniqueness constraints', :default => true
+    method_option :section, :enum => ['pre', 'post', 'all'], :desc => 'Schema section', :default => 'all'
     def dump_exec
       print_catalog
       exit
@@ -49,9 +47,9 @@ module Masamune::Tasks
     def print_catalog
       case options[:type]
       when 'psql'
-        puts define_schema(catalog, :postgres, options.slice(:with_index, :with_foreign_key, :with_unique_constraint).to_h.symbolize_keys)
+        puts define_schema(catalog, :postgres, options[:section].to_sym)
       when 'hql'
-        puts define_schema(catalog, :hive)
+        puts define_schema(catalog, :hive, options[:section].to_sym)
       end
     end
   end

--- a/lib/masamune/template.rb
+++ b/lib/masamune/template.rb
@@ -56,7 +56,7 @@ module Masamune
       end
 
       def render_to_string(template, parameters = {})
-        instance = Template.new(File.dirname(template))
+        instance = self.new(File.dirname(template))
         combine instance.render(template, parameters)
       end
 

--- a/lib/masamune/transform/define_inheritance.psql.erb
+++ b/lib/masamune/transform/define_inheritance.psql.erb
@@ -1,0 +1,28 @@
+--  The MIT License (MIT)
+--
+--  Copyright (c) 2014-2015, VMware, Inc. All Rights Reserved.
+--
+--  Permission is hereby granted, free of charge, to any person obtaining a copy
+--  of this software and associated documentation files (the "Software"), to deal
+--  in the Software without restriction, including without limitation the rights
+--  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--  copies of the Software, and to permit persons to whom the Software is
+--  furnished to do so, subject to the following conditions:
+--
+--  The above copyright notice and this permission notice shall be included in
+--  all copies or substantial portions of the Software.
+--
+--  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+--  THE SOFTWARE.
+
+<%- if target.parent -%>
+ALTER TABLE <%= target.name %> INHERIT <%= target.parent.name %>;
+<%- end -%>
+<%- if target.constraints -%>
+ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_time_key_check <%= target.constraints %>;
+<%- end -%>

--- a/lib/masamune/transform/define_inheritance.psql.erb
+++ b/lib/masamune/transform/define_inheritance.psql.erb
@@ -23,6 +23,6 @@
 <%- if target.parent -%>
 ALTER TABLE <%= target.name %> INHERIT <%= target.parent.name %>;
 <%- end -%>
-<%- if target.constraints -%>
-ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_time_key_check <%= target.constraints %>;
+<%- if target.inheritance_constraints -%>
+ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_time_key_check <%= target.inheritance_constraints %>;
 <%- end -%>

--- a/lib/masamune/transform/define_schema.rb
+++ b/lib/masamune/transform/define_schema.rb
@@ -28,18 +28,18 @@ module Masamune::Transform
 
     extend ActiveSupport::Concern
 
-    def define_schema(catalog, store_id, options = {})
+    def define_schema(catalog, store_id, section = :all)
       context = catalog[store_id]
       operators = []
 
       operators += context.extra(:pre)
 
       context.dimensions.each do |_, dimension|
-        operators << define_table(dimension, [], options)
+        operators << define_table(dimension, [], section)
       end
 
       context.facts.each do |_, fact|
-        operators << define_table(fact, [], options)
+        operators << define_table(fact, [], section)
       end
 
       operators += context.extra(:post)

--- a/lib/masamune/transform/define_schema.rb
+++ b/lib/masamune/transform/define_schema.rb
@@ -40,10 +40,9 @@ module Masamune::Transform
 
       context.facts.each do |_, fact|
         operators << define_table(fact, [], options[:section])
-        (options[:start_date] .. options[:stop_date]).each do |date|
-          next unless date.day == 1
-          operators << define_table(fact.partition_table(date.to_time), [], options[:section])
-        end if options[:start_date] && options[:stop_date]
+        fact.partition_tables(options[:start_date], options[:stop_date]) do |fact_partition_table|
+          operators << define_table(fact_partition_table, [], options[:section])
+        end
       end
 
       operators += context.extra(:post)

--- a/lib/masamune/transform/define_table.psql.erb
+++ b/lib/masamune/transform/define_table.psql.erb
@@ -116,7 +116,7 @@ WHERE NOT EXISTS (SELECT 1 FROM <%= target.name %> WHERE <%= row.insert_constrai
 ANALYZE <%= target.name %>;
 <%- end -%>
 
-<%- if helper.insert_rows? -%>
+<%- if helper.define_functions? -%>
 <% target.aliased_rows.each do |row| %>
 <%- row.natural_keys.each do |column| -%>
 CREATE OR REPLACE FUNCTION <%= row.name(column) %>

--- a/lib/masamune/transform/define_table.psql.erb
+++ b/lib/masamune/transform/define_table.psql.erb
@@ -92,6 +92,10 @@ COPY <%= target.name %> FROM '<%= file %>' WITH (<%= copy_options.join(", ") %>)
 <%- end -%>
 <%- end -%>
 
+<%- if helper.define_inheritance? -%>
+<%= render 'define_inheritance.psql.erb', target: target %>
+<%- end -%>
+
 <%- if helper.define_unique_constraints? -%>
 <%= render 'define_unique.psql.erb', target: target %>
 <%- end -%>

--- a/lib/masamune/transform/define_table.psql.erb
+++ b/lib/masamune/transform/define_table.psql.erb
@@ -22,22 +22,22 @@
 
 <%
   files ||= []
-  with_index = locals.fetch(:with_index, true)
-  with_foreign_key = locals.fetch(:with_foreign_key, true)
-  with_unique_constraint = locals.fetch(:with_unique_constraint, true)
 %>
 
 <%- target.children.each do |child| -%>
 <%= render 'define_table.psql.erb', target: child, **locals.except(:target, :files)  %>
 <%- end -%>
 
+<%- if helper.define_types? %>
 <%- target.enum_columns.each do |_, column| -%>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 FROM pg_type t WHERE LOWER(t.typname) = LOWER('<%= column.sql_type %>')) THEN
 CREATE TYPE <%= column.sql_type %> AS ENUM (<%= column.values.map { |value| "'#{value}'" }.join(', ') %>);
 END IF; END $$;
 <%- end -%>
+<%- end -%>
 
+<%- if helper.define_sequences? %>
 <%- target.sequence_columns.each do |_, column| -%>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= column.sequence_id %>') THEN
@@ -45,7 +45,9 @@ CREATE SEQUENCE <%= column.sequence_id %>;
 ALTER SEQUENCE <%= column.sequence_id %> RESTART <%= column.sequence_offset %>;
 END IF; END $$;
 <%- end -%>
+<%- end -%>
 
+<%- if helper.define_tables? %>
 <%- if target.temporary? -%>
 CREATE TEMPORARY TABLE IF NOT EXISTS <%= target.name %>
 <%- else -%>
@@ -56,25 +58,29 @@ CREATE TABLE IF NOT EXISTS <%= target.name %>
   <%= column.as_psql %><%= ',' unless last %>
   <%- end -%>
 );
+<%- end -%>
 
-<%- unless target.temporary? || target.primary_keys.empty? -%>
+<%- if helper.define_primary_keys? %>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = '<%= target.name %>_pkey') THEN
 ALTER TABLE <%= target.name %> ADD PRIMARY KEY (<%= target.primary_keys.map(&:name).join(', ') %>);
 END IF; END $$;
 <%- end -%>
 
-<%- if with_foreign_key && !target.delay_constraints? -%>
+<%- if helper.define_foreign_keys? -%>
 <%= render 'define_foreign_key.psql.erb', target: target %>
 <%- end -%>
 
+<%- if helper.define_sequences? -%>
 <%- target.sequence_columns.each do |_, column| -%>
 DO $$ BEGIN
 IF NOT EXISTS (SELECT 1 WHERE sequence_owner('<%= column.sequence_id %>') = '<%= column.qualified_name %>') THEN
 ALTER SEQUENCE <%= column.sequence_id %> OWNED BY <%= column.qualified_name %>;
 END IF; END $$;
 <%- end -%>
+<%- end -%>
 
+<%- if helper.load_files? -%>
 <%- files.each do |file| -%>
 <%-
   copy_options = []
@@ -84,25 +90,29 @@ END IF; END $$;
 -%>
 COPY <%= target.name %> FROM '<%= file %>' WITH (<%= copy_options.join(", ") %>);
 <%- end -%>
+<%- end -%>
 
-<%- if with_unique_constraint && !target.delay_constraints? -%>
+<%- if helper.define_unique_constraints? -%>
 <%= render 'define_unique.psql.erb', target: target %>
 <%- end -%>
 
-<%- if with_index && !target.delay_index? -%>
+<%- if helper.define_indexes? -%>
 <%= render 'define_index.psql.erb', target: target %>
 <%- end -%>
 
+<%- if helper.insert_rows? -%>
 <% target.insert_rows.each do |row| %>
 INSERT INTO <%= target.name %> (<%= row.insert_columns.join(', ') %>)
 SELECT <%= row.insert_values.join(', ') %>
 WHERE NOT EXISTS (SELECT 1 FROM <%= target.name %> WHERE <%= row.insert_constraints.join(' AND ') %>);
 <%- end -%>
+<%- end -%>
 
-<%- if files.any? || target.insert_rows.any? -%>
+<%- if helper.perform_analyze? -%>
 ANALYZE <%= target.name %>;
 <%- end -%>
 
+<%- if helper.insert_rows? -%>
 <% target.aliased_rows.each do |row| %>
 <%- row.natural_keys.each do |column| -%>
 CREATE OR REPLACE FUNCTION <%= row.name(column) %>
@@ -117,4 +127,5 @@ RETURNS <%= target.surrogate_key.sql_type %> IMMUTABLE AS $$
   SELECT <%= target.surrogate_key.name %> FROM <%= target.name %> WHERE <%= row.insert_constraints.join(' AND ') %>;
 $$ LANGUAGE SQL;
 
+<%- end -%>
 <%- end -%>

--- a/lib/masamune/transform/define_table.rb
+++ b/lib/masamune/transform/define_table.rb
@@ -116,7 +116,7 @@ module Masamune::Transform
       end
 
       def inherited?
-        type == :fact && inherit
+        type == :fact && inheritance_constraints
       end
 
       def delay_indexes?

--- a/lib/masamune/transform/define_table.rb
+++ b/lib/masamune/transform/define_table.rb
@@ -56,6 +56,13 @@ module Masamune::Transform
         !pre_section? && !(target.temporary? || target.primary_keys.empty?)
       end
 
+      def define_inheritance?
+        return false unless target.inherited?
+        return false if pre_section?
+        return true if post_section?
+        !target.delay_indexes?
+      end
+
       def define_indexes?
         return false if pre_section?
         return true if post_section?
@@ -106,6 +113,10 @@ module Masamune::Transform
     class Postgres < SimpleDelegator
       def children
         super.map { |child| self.class.new(child) }
+      end
+
+      def inherited?
+        type == :fact && inherit
       end
 
       def delay_indexes?

--- a/lib/masamune/transform/define_table.rb
+++ b/lib/masamune/transform/define_table.rb
@@ -24,7 +24,7 @@ module Masamune::Transform
   module DefineTable
     extend ActiveSupport::Concern
 
-    def define_table(target, files = [], section = :all)
+    def define_table(target, files = [], section = nil)
       return if target.implicit
       Operator.new(__method__, target: target, files: Masamune::Schema::Map.convert_files(files), section: section, helper: Helper, presenters: { postgres: Postgres, hive: Hive }).tap do |operator|
         logger.debug("#{target.id}\n" + operator.to_s) if target.debug
@@ -37,7 +37,7 @@ module Masamune::Transform
       end
 
       def section
-        locals[:section]
+        locals[:section] || :all
       end
 
       def define_types?
@@ -86,7 +86,7 @@ module Masamune::Transform
       end
 
       def insert_rows?
-        all_section?
+        !post_section?
       end
 
       def load_files?

--- a/lib/masamune/transform/define_table.rb
+++ b/lib/masamune/transform/define_table.rb
@@ -53,7 +53,7 @@ module Masamune::Transform
       end
 
       def define_primary_keys?
-        !post_section? && !(target.temporary? || target.primary_keys.empty?)
+        !pre_section? && !(target.temporary? || target.primary_keys.empty?)
       end
 
       def define_indexes?
@@ -69,8 +69,8 @@ module Masamune::Transform
       end
 
       def define_unique_constraints?
-        return true if pre_section?
-        return false if post_section?
+        return false if pre_section?
+        return true if post_section?
         !target.delay_unique_constraints?
       end
 

--- a/lib/masamune/transform/define_table.rb
+++ b/lib/masamune/transform/define_table.rb
@@ -24,10 +24,82 @@ module Masamune::Transform
   module DefineTable
     extend ActiveSupport::Concern
 
-    def define_table(target, files = [], options = {})
+    def define_table(target, files = [], section = :all)
       return if target.implicit
-      Operator.new(__method__, target: target, files: Masamune::Schema::Map.convert_files(files), **options.slice(:with_index, :with_foreign_key, :with_unique_constraint), presenters: { postgres: Postgres, hive: Hive }).tap do |operator|
+      Operator.new(__method__, target: target, files: Masamune::Schema::Map.convert_files(files), section: section, helper: Helper, presenters: { postgres: Postgres, hive: Hive }).tap do |operator|
         logger.debug("#{target.id}\n" + operator.to_s) if target.debug
+      end
+    end
+
+    class Helper < SimpleDelegator
+      def files
+        locals[:files]
+      end
+
+      def section
+        locals[:section]
+      end
+
+      def define_types?
+        !post_section?
+      end
+
+      def define_tables?
+        !post_section?
+      end
+
+      def define_sequences?
+        !post_section?
+      end
+
+      def define_primary_keys?
+        !post_section? && !(target.temporary? || target.primary_keys.empty?)
+      end
+
+      def define_indexes?
+        return false if pre_section?
+        return true if post_section?
+        !target.delay_indexes?
+      end
+
+      def define_foreign_keys?
+        return false if pre_section?
+        return true if post_section?
+        !target.delay_foreign_keys?
+      end
+
+      def define_unique_constraints?
+        return true if pre_section?
+        return false if post_section?
+        !target.delay_unique_constraints?
+      end
+
+      def insert_rows?
+        all_section?
+      end
+
+      def load_files?
+        all_section?
+      end
+
+      def perform_analyze?
+        return false if pre_section?
+        return true if post_section?
+        files.any? || target.insert_rows.any?
+      end
+
+      private
+
+      def all_section?
+        section == :all
+      end
+
+      def pre_section?
+        section == :pre
+      end
+
+      def post_section?
+        section == :post
       end
     end
 
@@ -36,11 +108,15 @@ module Masamune::Transform
         super.map { |child| self.class.new(child) }
       end
 
-      def delay_index?
+      def delay_indexes?
         type == :fact
       end
 
-      def delay_constraints?
+      def delay_foreign_keys?
+        type == :fact
+      end
+
+      def delay_unique_constraints?
         type == :fact
       end
     end

--- a/lib/masamune/transform/define_table.rb
+++ b/lib/masamune/transform/define_table.rb
@@ -48,6 +48,10 @@ module Masamune::Transform
         !post_section?
       end
 
+      def define_functions?
+        !post_section?
+      end
+
       def define_sequences?
         !post_section?
       end

--- a/lib/masamune/transform/operator.rb
+++ b/lib/masamune/transform/operator.rb
@@ -28,6 +28,7 @@ module Masamune::Transform
       @source     = options.delete(:source)
       @target     = options.delete(:target)
       @presenters = options.delete(:presenters) || {}
+      @helper     = options.delete(:helper) 
       @locals     = options
     end
 
@@ -39,6 +40,14 @@ module Masamune::Transform
     def target
       return unless @target
       @presenters.key?(target_store.try(:type)) ? @presenters[target_store.try(:type)].new(@target) : @target
+    end
+
+    def helper
+      (@helper || SimpleDelegator).new(self)
+    end
+
+    def locals
+      @locals
     end
 
     def to_s
@@ -76,7 +85,7 @@ module Masamune::Transform
     def template_eval(template)
       return File.read(template) if File.exists?(template.to_s) && template.to_s !~ /erb\Z/
       template_file = File.exists?(template.to_s) ? template : template_file(template)
-      Masamune::Template.render_to_string(template_file, @locals.merge(source: source, target: target))
+      Masamune::Template.render_to_string(template_file, @locals.merge(source: source, target: target, helper: helper))
     end
 
     def template_file(template_prefix)

--- a/lib/masamune/transform/operator.rb
+++ b/lib/masamune/transform/operator.rb
@@ -28,7 +28,7 @@ module Masamune::Transform
       @source     = options.delete(:source)
       @target     = options.delete(:target)
       @presenters = options.delete(:presenters) || {}
-      @helper     = options.delete(:helper) 
+      @helper     = options.delete(:helper)
       @locals     = options
     end
 

--- a/lib/masamune/transform/replace_table.psql.erb
+++ b/lib/masamune/transform/replace_table.psql.erb
@@ -43,12 +43,8 @@ DROP INDEX IF EXISTS <%= index_name %>;
 ALTER TABLE <%= target.name %> RENAME TO <%= target_tmp.name %>;
 ALTER TABLE <%= source.name %> RENAME TO <%= target.name %>;
 
-<%- if target.parent -%>
-ALTER TABLE <%= target.name %> INHERIT <%= target.parent.name %>;
-<%- end -%>
-<%- if target.constraints -%>
-ALTER TABLE <%= target.name %> ADD CONSTRAINT <%= target.name %>_time_key_check <%= target.constraints %>;
-<%- end -%>
+<%= render 'define_inheritance.psql.erb', target: target %>
+
 <%= render 'define_foreign_key.psql.erb', target: target, skip_check_exist: true, skip_check_valid: true %>
 
 <%= render 'define_index.psql.erb', target: target, skip_check_exist: true %>

--- a/spec/masamune/data_plan/engine_spec.rb
+++ b/spec/masamune/data_plan/engine_spec.rb
@@ -177,7 +177,7 @@ describe Masamune::DataPlan::Engine do
     context 'invalid target' do
       let(:rule) { 'derived_daily' }
       let(:target) {  '/table/y=2013/m=01/d=01' }
-      it { expect { subject }.to raise_error }
+      it { expect { subject }.to raise_error /Cannot bind_input/ }
     end
   end
 
@@ -206,7 +206,7 @@ describe Masamune::DataPlan::Engine do
 
     context 'invalid target' do
       let(:target) { '/daily' }
-      it { expect { subject }.to raise_error }
+      it { expect { subject }.to raise_error /No rule matches/ }
     end
   end
 

--- a/spec/masamune/data_plan/rule_spec.rb
+++ b/spec/masamune/data_plan/rule_spec.rb
@@ -47,30 +47,45 @@ describe Masamune::DataPlan::Rule do
     end
   end
 
-  describe '#bind_date' do
-    subject(:elem) { instance.bind_date(input_date) }
+  describe '#bind_date_or_time' do
+    subject(:elem) { instance.bind_date_or_time(input) }
 
-    context 'with default' do
-      let(:input_date) { DateTime.civil(2013,04,05,23,13) }
+    context 'with nil input' do
+      let(:input) { nil }
+      it { expect { elem }.to raise_error ArgumentError }
+    end
+
+    context 'with unknown input type' do
+      let(:input) { 1 }
+      it { expect { elem }.to raise_error ArgumentError }
+    end
+
+    context 'with DateTime input' do
+      let(:input) { DateTime.civil(2013,04,05,23,13) }
 
       describe '#path' do
         subject { elem.path }
         it { is_expected.to eq('report/2013-04-05/23') }
       end
-      let(:start_time) { DateTime.civil(2013,04,05,23) }
-      let(:stop_time) { DateTime.civil(2013,04,05,0) }
     end
 
-    context 'with unix timestamp pattern' do
+    context 'with DateTime input and unix timestamp pattern' do
       let(:pattern) { 'logs/%H-s.log' }
-      let(:input_date) { DateTime.civil(2013,04,05,23,13) }
+      let(:input) { DateTime.civil(2013,04,05,23,13) }
 
       describe '#path' do
         subject { elem.path }
         it { is_expected.to eq('logs/1365202800.log') }
       end
-      let(:start_time) { DateTime.civil(2013,04,05,23) }
-      let(:stop_time) { DateTime.civil(2013,04,05,0) }
+    end
+
+    context 'with Date input' do
+      let(:input) { Date.civil(2013,04,05) }
+
+      describe '#path' do
+        subject { elem.path }
+        it { is_expected.to eq('report/2013-04-05/00') }
+      end
     end
   end
 

--- a/spec/masamune/schema/fact_spec.rb
+++ b/spec/masamune/schema/fact_spec.rb
@@ -40,7 +40,7 @@ describe Masamune::Schema::Fact do
       ]
   end
 
-  let(:fact) do
+  let(:fact_with_partition) do
     described_class.new id: 'visits', store: store, partition: 'y%Ym%m',
       references: [
         Masamune::Schema::TableReference.new(date_dimension),
@@ -53,35 +53,21 @@ describe Masamune::Schema::Fact do
       ]
   end
 
-  it { expect(fact.name).to eq('visits_fact') }
+  it { expect(fact_with_partition.name).to eq('visits_fact') }
 
-  describe '#partition_table' do
-    let(:date) { Chronic.parse('2015-01-01') }
-
-    subject(:partition_table) { fact.partition_table(date) }
-
-    it { expect(partition_table.store.id).to eq(store.id) }
-    it { expect(partition_table.name).to eq('visits_fact_y2015m01') }
-    it { expect(partition_table.range.start_date).to eq(date.utc.to_date) }
-
-    describe '#stage_table' do
-      subject(:stage_table) { partition_table.stage_table }
-
-      it { expect(stage_table.store.id).to eq(store.id) }
-      it { expect(stage_table.name).to eq('visits_fact_y2015m01_stage') }
-      it { expect(stage_table.range.start_date).to eq(date.utc.to_date) }
-
-      context 'with optional suffix' do
-        subject(:stage_table) { partition_table.stage_table(suffix: 'tmp') }
-
-        it 'should append suffix to id' do
-          expect(stage_table.store.id).to eq(store.id)
-          expect(stage_table.name).to eq('visits_fact_y2015m01_stage_tmp')
-          expect(stage_table.range.start_date).to eq(date.utc.to_date)
-        end
-      end
-    end
+  let(:fact_with_partition_and_hourly_grain) do
+    described_class.new id: 'visits', store: store, grain: :hourly, partition: 'y%Ym%m',
+      references: [
+        Masamune::Schema::TableReference.new(date_dimension),
+        Masamune::Schema::TableReference.new(user_dimension)
+      ],
+      columns: [
+        Masamune::Schema::Column.new(id: 'total', type: :integer)
+      ]
   end
+
+  it { expect(fact_with_partition_and_hourly_grain.id).to eq(:visits_hourly) }
+  it { expect(fact_with_partition_and_hourly_grain.name).to eq('visits_hourly_fact') }
 
   context 'fact with unknown grain' do
     subject(:fact) do
@@ -91,25 +77,38 @@ describe Masamune::Schema::Fact do
     it { expect { fact }.to raise_error ArgumentError, "unknown grain 'quarterly'" }
   end
 
-  context 'fact with :hourly grain' do
-    let(:fact) do
-      described_class.new id: 'visits', store: store, grain: :hourly, partition: 'y%Ym%m',
-        references: [
-          Masamune::Schema::TableReference.new(date_dimension),
-          Masamune::Schema::TableReference.new(user_dimension)
-        ],
-        columns: [
-          Masamune::Schema::Column.new(id: 'total', type: :integer)
-        ]
+  describe '#partition_table' do
+    let(:date) { Chronic.parse('2015-01-01') }
+    subject(:partition_table) { fact.partition_table(date) }
+
+    context 'fact with partition' do
+      let(:fact) { fact_with_partition }
+
+      it { expect(partition_table.store.id).to eq(store.id) }
+      it { expect(partition_table.name).to eq('visits_fact_y2015m01') }
+      it { expect(partition_table.range.start_date).to eq(date.utc.to_date) }
+
+      describe '#stage_table' do
+        subject(:stage_table) { partition_table.stage_table }
+
+        it { expect(stage_table.store.id).to eq(store.id) }
+        it { expect(stage_table.name).to eq('visits_fact_y2015m01_stage') }
+        it { expect(stage_table.range.start_date).to eq(date.utc.to_date) }
+
+        context 'with optional suffix' do
+          subject(:stage_table) { partition_table.stage_table(suffix: 'tmp') }
+
+          it 'should append suffix to id' do
+            expect(stage_table.store.id).to eq(store.id)
+            expect(stage_table.name).to eq('visits_fact_y2015m01_stage_tmp')
+            expect(stage_table.range.start_date).to eq(date.utc.to_date)
+          end
+        end
+      end
     end
 
-    it { expect(fact.id).to eq(:visits_hourly) }
-    it { expect(fact.name).to eq('visits_hourly_fact') }
-
-    describe '#partition_table' do
-      let(:date) { Chronic.parse('2015-01-01') }
-
-      subject(:partition_table) { fact.partition_table(date) }
+    context 'fact with partition and hourly grain' do
+      let(:fact) { fact_with_partition_and_hourly_grain }
 
       it { expect(partition_table.store.id).to eq(store.id) }
       it { expect(partition_table.name).to eq('visits_hourly_fact_y2015m01') }

--- a/spec/masamune/schema/fact_spec.rb
+++ b/spec/masamune/schema/fact_spec.rb
@@ -160,9 +160,9 @@ describe Masamune::Schema::Fact do
 
       it do
         expect { |b| fact.partition_tables(start_date, stop_date, &b) }.to yield_successive_args \
-           fact.partition_table(Date.civil(2015, 01, 01).to_time),
-           fact.partition_table(Date.civil(2015, 02, 01).to_time),
-           fact.partition_table(Date.civil(2015, 03, 01).to_time)
+           fact.partition_table(Date.civil(2015, 01, 01)),
+           fact.partition_table(Date.civil(2015, 02, 01)),
+           fact.partition_table(Date.civil(2015, 03, 01))
       end
     end
   end

--- a/spec/masamune/schema/fact_spec.rb
+++ b/spec/masamune/schema/fact_spec.rb
@@ -158,7 +158,7 @@ describe Masamune::Schema::Fact do
     context 'fact with partition' do
       let(:fact) { fact_with_partition }
 
-      it do
+      it 'yields partition tables' do
         expect { |b| fact.partition_tables(start_date, stop_date, &b) }.to yield_successive_args \
            fact.partition_table(Date.civil(2015, 01, 01)),
            fact.partition_table(Date.civil(2015, 02, 01)),

--- a/spec/masamune/tasks/dump_thor_spec.rb
+++ b/spec/masamune/tasks/dump_thor_spec.rb
@@ -69,4 +69,14 @@ describe Masamune::Tasks::DumpThor do
     let(:options) { ['--section=unknown'] }
     it_behaves_like 'raises Thor::MalformattedArgumentError', %q{Expected '--section' to be one of pre, post, all; got unknown}
   end
+
+  context 'with --start=yesterday' do
+    let(:options) { ['--start=yesterday'] }
+    it_behaves_like 'executes with success'
+  end
+
+  context 'with --stop=today' do
+    let(:options) { ['--stop=today'] }
+    it_behaves_like 'executes with success'
+  end
 end

--- a/spec/masamune/tasks/dump_thor_spec.rb
+++ b/spec/masamune/tasks/dump_thor_spec.rb
@@ -32,11 +32,41 @@ describe Masamune::Tasks::DumpThor do
   end
 
   context 'with no arguments' do
-    it 'exits with status code 0 and prints catalog' do
-      expect { cli_invocation }.to raise_error { |e|
-        expect(e).to be_a(SystemExit)
-        expect(e.status).to eq(0)
-      }
-    end
+    it_behaves_like 'executes with success'
+  end
+
+  context 'with --type=psql' do
+    let(:options) { ['--type=psql'] }
+    it_behaves_like 'executes with success'
+  end
+
+  context 'with --type=hql' do
+    let(:options) { ['--type=hql'] }
+    it_behaves_like 'executes with success'
+  end
+
+  context 'with --type=unknown' do
+    let(:options) { ['--type=unknown'] }
+    it_behaves_like 'raises Thor::MalformattedArgumentError', %q{Expected '--type' to be one of psql, hql; got unknown}
+  end
+
+  context 'with --section=pre' do
+    let(:options) { ['--section=pre'] }
+    it_behaves_like 'executes with success'
+  end
+
+  context 'with --section=post' do
+    let(:options) { ['--section=post'] }
+    it_behaves_like 'executes with success'
+  end
+
+  context 'with --section=all' do
+    let(:options) { ['--section=all'] }
+    it_behaves_like 'executes with success'
+  end
+
+  context 'with --section=unknown' do
+    let(:options) { ['--section=unknown'] }
+    it_behaves_like 'raises Thor::MalformattedArgumentError', %q{Expected '--section' to be one of pre, post, all; got unknown}
   end
 end

--- a/spec/masamune/thor_spec.rb
+++ b/spec/masamune/thor_spec.rb
@@ -160,27 +160,13 @@ describe Masamune::Thor do
     context 'with command and --start' do
       let(:command) { 'command' }
       let(:options) { ['--start', '2013-01-01'] }
-      it 'exits with status code 0 without error message' do
-        expect { cli_invocation }.to raise_error { |e|
-          expect(e).to be_a(SystemExit)
-          expect(e.status).to eq(0)
-        }
-        expect(stdout.string).to match(/\AUsing '.*' for --start/)
-        expect(stderr.string).to eq('')
-      end
+      it_behaves_like 'executes with success'
     end
 
     context 'with command and natural language --start' do
       let(:command) { 'command' }
       let(:options) { ['--start', 'yesterday'] }
-      it 'exits with status code  0 without error message' do
-        expect { cli_invocation }.to raise_error { |e|
-          expect(e).to be_a(SystemExit)
-          expect(e.status).to eq(0)
-        }
-        expect(stdout.string).to match(/\AUsing '.*' for --start/)
-        expect(stderr.string).to eq('')
-      end
+      it_behaves_like 'executes with success'
     end
 
     context 'with command that raises exception before initialization' do

--- a/spec/masamune/thor_spec.rb
+++ b/spec/masamune/thor_spec.rb
@@ -99,43 +99,44 @@ describe Masamune::Thor do
 
     context 'with command and no input options' do
       let(:command) { 'command' }
-      it { expect { cli_invocation }.to raise_error Thor::RequiredArgumentMissingError, /No value provided for required options '--start'/ }
+      it_behaves_like 'raises Thor::RequiredArgumentMissingError', /No value provided for required options '--start'/
     end
 
     context 'with command and invalid --start' do
       let(:command) { 'command' }
       let(:options) { ['--start', 'xxx'] }
-      it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, /Expected date time value for '--start'; got/ }
+      it_behaves_like 'raises Thor::MalformattedArgumentError', /Expected date time value for '--start'; got/
     end
 
     context 'with command and invalid --stop' do
       let(:command) { 'command' }
       let(:options) { ['--start', '2013-01-01', '--stop', 'xxx'] }
-      it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, /Expected date time value for '--stop'; got/ }
+      it_behaves_like 'raises Thor::MalformattedArgumentError', /Expected date time value for '--stop'; got/
     end
 
     context 'with command and invalid --sources' do
       let(:command) { 'command' }
       let(:options) { ['--sources', 'foo'] }
-      it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, /Expected file value for '--sources'; got/ }
+      it_behaves_like 'raises Thor::MalformattedArgumentError', /Expected file value for '--sources'; got/
     end
 
     context 'with command and invalid --targets' do
       let(:command) { 'command' }
       let(:options) { ['--targets', 'foo'] }
-      it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, /Expected file value for '--targets'; got/ }
+      it_behaves_like 'raises Thor::MalformattedArgumentError', /Expected file value for '--targets'; got/
     end
 
     context 'with command and both --sources and --targets' do
       let(:command) { 'command' }
       let(:options) { ['--sources', 'sources', '--targets', 'targets'] }
-      it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, /Cannot specify both option '--sources' and option '--targets'/ }
+
+      it_behaves_like 'raises Thor::MalformattedArgumentError', /Cannot specify both option '--sources' and option '--targets'/
     end
 
     context 'with command and --start and bad --config file' do
       let(:command) { 'command' }
       let(:options) { ['--start', '2013-01-01', '--config', 'xxx'] }
-      it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, /Could not load file provided for '--config'/ }
+      it_behaves_like 'raises Thor::MalformattedArgumentError', /Could not load file provided for '--config'/
     end
 
     context 'with command and --start and missing system --config file' do
@@ -144,7 +145,7 @@ describe Masamune::Thor do
       before do
         expect_any_instance_of(Masamune::Filesystem).to receive(:resolve_file)
       end
-      it { expect { cli_invocation }.to raise_error Thor::RequiredArgumentMissingError, /Option --config or valid system configuration file required/ }
+      it_behaves_like 'raises Thor::RequiredArgumentMissingError', /Option --config or valid system configuration file required/
     end
 
     context 'with command and -- --extra --args' do
@@ -153,9 +154,7 @@ describe Masamune::Thor do
       before do
         expect_any_instance_of(thor_class).to receive(:extra=).with(['--extra', '--args'])
       end
-      it do
-        expect { cli_invocation }.to raise_error SystemExit
-      end
+      it_behaves_like 'executes with success'
     end
 
     context 'with command and --start' do

--- a/spec/masamune/transform/define_schema_spec.rb
+++ b/spec/masamune/transform/define_schema_spec.rb
@@ -38,6 +38,12 @@ describe Masamune::Transform::DefineSchema do
           column 'preferences', type: :key_value, null: true
         end
 
+        fact 'visits', partition: 'y%Ym%m' do
+          partition :y
+          partition :m
+          measure 'total', type: :integer
+        end
+
         file 'user' do
           column 'tenant_id', type: :integer
           column 'user_id', type: :integer
@@ -50,13 +56,31 @@ describe Masamune::Transform::DefineSchema do
       end
     end
 
-    subject(:result) { transform.define_schema(catalog, :postgres).to_s }
+    context 'without options' do
+      subject(:result) { transform.define_schema(catalog, :postgres).to_s }
 
-    it 'should render combined template' do
-      is_expected.to eq Masamune::Template.combine \
-        Masamune::Transform::Operator.new('define_schema', source: catalog.postgres),
-        transform.define_table(catalog.postgres.dimensions['user_account_state']),
-        transform.define_table(catalog.postgres.dimensions['user'])
+      it 'should render combined template' do
+        is_expected.to eq Masamune::Template.combine \
+          Masamune::Transform::Operator.new('define_schema', source: catalog.postgres),
+          transform.define_table(catalog.postgres.dimensions['user_account_state']),
+          transform.define_table(catalog.postgres.dimensions['user']),
+          transform.define_table(catalog.postgres.facts['visits'])
+      end
+    end
+
+    context 'without start_date and stop_date' do
+      subject(:result) { transform.define_schema(catalog, :postgres, start_date: Date.civil(2015, 01, 01), stop_date: Date.civil(2015, 03, 15)).to_s }
+
+      it 'should render combined template' do
+        is_expected.to eq Masamune::Template.combine \
+          Masamune::Transform::Operator.new('define_schema', source: catalog.postgres),
+          transform.define_table(catalog.postgres.dimensions['user_account_state']),
+          transform.define_table(catalog.postgres.dimensions['user']),
+          transform.define_table(catalog.postgres.facts['visits']),
+          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 01, 01).to_time)),
+          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 02, 01).to_time)),
+          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 03, 01).to_time))
+      end
     end
   end
 

--- a/spec/masamune/transform/define_schema_spec.rb
+++ b/spec/masamune/transform/define_schema_spec.rb
@@ -77,9 +77,9 @@ describe Masamune::Transform::DefineSchema do
           transform.define_table(catalog.postgres.dimensions['user_account_state']),
           transform.define_table(catalog.postgres.dimensions['user']),
           transform.define_table(catalog.postgres.facts['visits']),
-          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 01, 01).to_time)),
-          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 02, 01).to_time)),
-          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 03, 01).to_time))
+          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 01, 01))),
+          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 02, 01))),
+          transform.define_table(catalog.postgres.facts['visits'].partition_table(Date.civil(2015, 03, 01)))
       end
     end
   end

--- a/spec/masamune/transform/define_table.fact_spec.rb
+++ b/spec/masamune/transform/define_table.fact_spec.rb
@@ -149,7 +149,7 @@ describe Masamune::Transform::DefineTable do
   end
 
   context 'for postgres fact partition with :post' do
-    let(:target) { catalog.postgres.visits_fact.partition_table(Date.civil(2015, 01, 01).to_time) }
+    let(:target) { catalog.postgres.visits_fact.partition_table(Date.civil(2015, 01, 01)) }
 
     subject(:result) { transform.define_table(target, [], :post).to_s }
 

--- a/spec/masamune/transform/define_table.fact_spec.rb
+++ b/spec/masamune/transform/define_table.fact_spec.rb
@@ -148,6 +148,17 @@ describe Masamune::Transform::DefineTable do
     end
   end
 
+  context 'for postgres fact partition with :post' do
+    let(:target) { catalog.postgres.visits_fact.partition_table(Date.civil(2015, 01, 01).to_time) }
+
+    subject(:result) { transform.define_table(target, [], :post).to_s }
+
+    it 'should eq render table template' do
+      is_expected.to match /ALTER TABLE visits_fact_y2015m01 INHERIT visits_fact;/
+      is_expected.to match /ALTER TABLE visits_fact_y2015m01 ADD CONSTRAINT visits_fact_y2015m01_time_key_check CHECK \(time_key >= 1420070400 AND time_key < 1422748800\);/
+    end
+  end
+
   describe 'for fact table from file with sources files' do
     let(:files) { (1..3).map { |i| double(path: "output_#{i}.csv") } }
     let(:target) { catalog.postgres.visits_fact }

--- a/spec/masamune/transform/define_table.table_spec.rb
+++ b/spec/masamune/transform/define_table.table_spec.rb
@@ -815,11 +815,6 @@ describe Masamune::Transform::DefineTable do
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
-        ALTER TABLE user_table ADD PRIMARY KEY (id);
-        END IF; END $$;
       EOS
     end
   end
@@ -853,11 +848,6 @@ describe Masamune::Transform::DefineTable do
           user_account_state_table_id INTEGER NOT NULL DEFAULT default_user_account_state_table_id(),
           name VARCHAR NOT NULL
         );
-
-        DO $$ BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
-        ALTER TABLE user_table ADD PRIMARY KEY (id);
-        END IF; END $$;
       EOS
     end
   end
@@ -883,7 +873,25 @@ describe Masamune::Transform::DefineTable do
           tenant_id INTEGER NOT NULL,
           user_id INTEGER NOT NULL
         );
+      EOS
+    end
+  end
 
+  context 'for postgres table with unique columns and section :post' do
+    before do
+      catalog.schema :postgres do
+        table 'user' do
+          column 'tenant_id', unique: true
+          column 'user_id'
+        end
+      end
+    end
+
+    let(:section) { :post }
+    let(:target) { catalog.postgres.user_table }
+
+    it 'should render table template' do
+      is_expected.to eq <<-EOS.strip_heredoc
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
         ALTER TABLE user_table ADD PRIMARY KEY (id);
@@ -893,6 +901,8 @@ describe Masamune::Transform::DefineTable do
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_key') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_3854361_key UNIQUE(tenant_id);
         END IF; END $$;
+
+        ANALYZE user_table;
       EOS
     end
   end
@@ -912,6 +922,11 @@ describe Masamune::Transform::DefineTable do
 
     it 'should render table template' do
       is_expected.to eq <<-EOS.strip_heredoc
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
+
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_3854361_index') THEN
         CREATE INDEX user_table_3854361_index ON user_table (tenant_id);
@@ -950,6 +965,11 @@ describe Masamune::Transform::DefineTable do
 
     it 'should render table template' do
       is_expected.to eq <<-EOS.strip_heredoc
+        DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_class c WHERE c.relname = 'user_table_pkey') THEN
+        ALTER TABLE user_table ADD PRIMARY KEY (id);
+        END IF; END $$;
+
         DO $$ BEGIN
         IF NOT EXISTS (SELECT 1 FROM pg_constraint c WHERE c.conname = 'user_table_bd2027e_fkey') THEN
         ALTER TABLE user_table ADD CONSTRAINT user_table_bd2027e_fkey FOREIGN KEY (user_account_state_table_id) REFERENCES user_account_state_table(id);

--- a/spec/masamune/transform/rollup_fact_spec.rb
+++ b/spec/masamune/transform/rollup_fact_spec.rb
@@ -156,6 +156,7 @@ describe Masamune::Transform::RollupFact do
 
         ALTER TABLE visits_hourly_fact_y2014m08 INHERIT visits_hourly_fact;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
+
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_0a531a8_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_d3950d9_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
@@ -257,6 +258,7 @@ describe Masamune::Transform::RollupFact do
 
         ALTER TABLE visits_daily_fact_y2014m08 INHERIT visits_daily_fact;
         ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
+
         ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
         ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_0a531a8_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
         ALTER TABLE visits_daily_fact_y2014m08 ADD CONSTRAINT visits_daily_fact_y2014m08_d3950d9_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
@@ -358,6 +360,7 @@ describe Masamune::Transform::RollupFact do
 
         ALTER TABLE visits_monthly_fact_y2014m08 INHERIT visits_monthly_fact;
         ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
+
         ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
         ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_0a531a8_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
         ALTER TABLE visits_monthly_fact_y2014m08 ADD CONSTRAINT visits_monthly_fact_y2014m08_d3950d9_fkey FOREIGN KEY (tenant_dimension_id) REFERENCES tenant_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -211,6 +211,7 @@ describe Masamune::Transform::StageFact do
 
         ALTER TABLE visits_hourly_fact_y2014m08 INHERIT visits_hourly_fact;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_time_key_check CHECK (time_key >= 1406851200 AND time_key < 1409529600);
+
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_d6b9b38_fkey FOREIGN KEY (cluster_type_id) REFERENCES cluster_type(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_0a531a8_fkey FOREIGN KEY (date_dimension_id) REFERENCES date_dimension(id) NOT VALID DEFERRABLE INITIALLY DEFERRED;
         ALTER TABLE visits_hourly_fact_y2014m08 ADD CONSTRAINT visits_hourly_fact_y2014m08_ff74c56_fkey FOREIGN KEY (cluster_type_id, tenant_dimension_id) REFERENCES tenant_dimension(cluster_type_id, id) NOT VALID DEFERRABLE INITIALLY DEFERRED;

--- a/spec/support/rspec/example/task_example_group.rb
+++ b/spec/support/rspec/example/task_example_group.rb
@@ -52,6 +52,19 @@ module TaskExampleGroup
     end
   end
 
+  shared_examples 'executes with success' do
+    it 'exits with status code 0' do
+      expect { cli_invocation }.to raise_error { |e|
+        expect(e).to be_a(SystemExit)
+        expect(e.status).to eq(0)
+      }
+    end
+  end
+
+  shared_examples 'raises Thor::MalformattedArgumentError' do |message|
+    it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, message }
+  end
+
   def self.included(base)
     base.before :all do
       ENV['THOR_DEBUG'] = '1'

--- a/spec/support/rspec/example/task_example_group.rb
+++ b/spec/support/rspec/example/task_example_group.rb
@@ -65,6 +65,10 @@ module TaskExampleGroup
     it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, message }
   end
 
+  shared_examples 'raises Thor::RequiredArgumentMissingError' do |message|
+    it { expect { cli_invocation }.to raise_error Thor::RequiredArgumentMissingError, message }
+  end
+
   def self.included(base)
     base.before :all do
       ENV['THOR_DEBUG'] = '1'


### PR DESCRIPTION
### Primary Changes
- Add `--section` to `masamune-dump`. Accepts `pre`, `post` and `all`. Similar to `pg_dump` but with `CREATE IF NOT EXISTS` guard clauses
- Optionally allow `--start` and `--stop` parameters in `masamune-dump`. Defines fact partition tables for date range.

### Misc
- Improve robustness of `DataPlan#bind_date` 
- Fix `rspec` `raises_error` warning
- Add helper convention to `Operator` template evaluation- provides helper functions that are not associated with `target` or `source` via presenter
- Encapsulate common `Task` expectations in `shared_example`
- Add `Schema::Fact#partition_tables` helper