### PR TITLE
Fix denormalize_table

### DIFF
--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -185,6 +185,7 @@ module Masamune::Schema
         next if column.surrogate_key || column.ignore
         if column.reference
           (column.reference.natural_keys.any? ? column.reference.natural_keys : column.reference.denormalized_columns).each do |join_column|
+            next if join_column.reference && join_column.natural_key
             yield [column.reference, join_column]
           end
         else

--- a/lib/masamune/schema/table.rb
+++ b/lib/masamune/schema/table.rb
@@ -183,9 +183,13 @@ module Masamune::Schema
       return to_enum(__method__).to_a.flatten.compact unless block_given?
       columns.map do |_, column|
         next if column.surrogate_key || column.ignore
-        if column.reference
-          (column.reference.natural_keys.any? ? column.reference.natural_keys : column.reference.denormalized_columns).each do |join_column|
+        if column.reference && column.reference.natural_keys.any?
+          column.reference.natural_keys.each do |join_column|
             next if join_column.reference && join_column.natural_key
+            yield [column.reference, join_column]
+          end
+        elsif column.reference && column.reference.denormalized_columns.any?
+          column.reference.denormalized_columns.each do |join_column|
             yield [column.reference, join_column]
           end
         else

--- a/lib/masamune/transform/denormalize_table.rb
+++ b/lib/masamune/transform/denormalize_table.rb
@@ -29,6 +29,7 @@ module Masamune::Transform
       columns = options[:include] || []
       columns += options[:columns] || target.denormalized_column_names
       columns -= options[:except] || []
+      columns -= ['last_modified_at']
       order_by = options[:order] || columns
       Operator.new(__method__, target: target, columns: columns, order_by: order_by, presenters: { postgres: Common, hive: Common })
     end

--- a/lib/masamune/transform/denormalize_table.rb
+++ b/lib/masamune/transform/denormalize_table.rb
@@ -30,6 +30,7 @@ module Masamune::Transform
       columns += options[:columns] || target.denormalized_column_names
       columns -= options[:except] || []
       columns -= ['last_modified_at']
+      columns.uniq!
       order_by = options[:order] || columns
       Operator.new(__method__, target: target, columns: columns, order_by: order_by, presenters: { postgres: Common, hive: Common })
     end

--- a/lib/masamune/transform/denormalize_table.rb
+++ b/lib/masamune/transform/denormalize_table.rb
@@ -65,6 +65,7 @@ module Masamune::Transform
           column_names.each do |column_name|
             next unless column = dereference_column_name(column_name)
             next unless column.reference
+            next if column.reference.degenerate
             adjacent_reference = references[column.reference.id]
             next unless adjacent_reference
             adjacent_column = columns[adjacent_reference.foreign_key_name]

--- a/spec/masamune/transform/denormalize_table_spec.rb
+++ b/spec/masamune/transform/denormalize_table_spec.rb
@@ -63,6 +63,7 @@ describe Masamune::Transform::DenormalizeTable do
         references :user, label: 'manager'
         references :user
         references :user_agent
+        references :session, degenerate: true
         measure 'total', type: :integer
       end
     end
@@ -89,6 +90,7 @@ describe Masamune::Transform::DenormalizeTable do
         user_agent_type.name AS user_agent_type_name,
         user_agent_type.version AS user_agent_type_version,
         user_agent_type.mobile AS user_agent_type_mobile,
+        session_type_id AS session_type_id,
         visits_fact.total,
         visits_fact.time_key
       FROM
@@ -128,6 +130,7 @@ describe Masamune::Transform::DenormalizeTable do
         user_agent_type_name,
         user_agent_type_version,
         user_agent_type_mobile,
+        session_type_id,
         total,
         time_key
       ;
@@ -226,6 +229,7 @@ describe Masamune::Transform::DenormalizeTable do
         user_agent_type.name AS user_agent_type_name,
         user_agent_type.version AS user_agent_type_version,
         user_agent_type.mobile AS user_agent_type_mobile,
+        session_type_id AS session_type_id,
         visits_fact.total,
         visits_fact.time_key
       FROM
@@ -260,6 +264,7 @@ describe Masamune::Transform::DenormalizeTable do
         user_agent_type_name,
         user_agent_type_version,
         user_agent_type_mobile,
+        session_type_id,
         total,
         time_key
       ;

--- a/spec/masamune/transform/denormalize_table_spec.rb
+++ b/spec/masamune/transform/denormalize_table_spec.rb
@@ -42,12 +42,14 @@ describe Masamune::Transform::DenormalizeTable do
       end
 
       dimension 'user', type: :two do
+        references :cluster
         column 'tenant_id', type: :integer, index: true, natural_key: true
         column 'user_id', type: :integer, index: true, natural_key: true
         column 'name', type: :string
       end
 
       dimension 'user_agent', type: :mini do
+        references :cluster
         column 'name', type: :string, unique: true, index: 'shared'
         column 'version', type: :string, unique: true, index: 'shared', default: 'Unknown'
         column 'mobile', type: :boolean, unique: true, index: 'shared', default: false


### PR DESCRIPTION
- Ensure there are no duplicate columns due to multiple references of the same column
- Skip `reference` columns that are also considered `natural_keys`
- Always omit `last_modifed_at` reserved column