### PR TITLE
[SBI-636] VACUUM FULL ANALYZE instead of ANALYZE

### DIFF
--- a/lib/masamune/transform/bulk_upsert.psql.erb
+++ b/lib/masamune/transform/bulk_upsert.psql.erb
@@ -61,6 +61,6 @@ WHERE
 ;
 <%- end -%>
 
-ANALYZE <%= target.name %>;
+VACUUM FULL ANALYZE <%= target.name %>;
 
 COMMIT;

--- a/lib/masamune/transform/define_table.psql.erb
+++ b/lib/masamune/transform/define_table.psql.erb
@@ -113,7 +113,7 @@ WHERE NOT EXISTS (SELECT 1 FROM <%= target.name %> WHERE <%= row.insert_constrai
 <%- end -%>
 
 <%- if helper.perform_analyze? -%>
-ANALYZE <%= target.name %>;
+VACUUM FULL ANALYZE <%= target.name %>;
 <%- end -%>
 
 <%- if helper.define_functions? -%>

--- a/lib/masamune/transform/insert_reference_values.psql.erb
+++ b/lib/masamune/transform/insert_reference_values.psql.erb
@@ -39,7 +39,7 @@ WHERE
 <%- end -%>
 ;
 
-ANALYZE <%= target.stage_table.name %>;
+VACUUM FULL ANALYZE <%= target.stage_table.name %>;
 
 <%= target.bulk_upsert(target.stage_table, target) %>
 <%- end -%>

--- a/lib/masamune/transform/replace_table.psql.erb
+++ b/lib/masamune/transform/replace_table.psql.erb
@@ -49,7 +49,7 @@ ALTER TABLE <%= source.name %> RENAME TO <%= target.name %>;
 
 <%= render 'define_index.psql.erb', target: target, skip_check_exist: true %>
 
-ANALYZE <%= target.name %>;
+VACUUM FULL ANALYZE <%= target.name %>;
 
 COMMIT;
 

--- a/lib/masamune/transform/stage_dimension.psql.erb
+++ b/lib/masamune/transform/stage_dimension.psql.erb
@@ -38,4 +38,4 @@ ON
 <%- end -%>
 ;
 
-ANALYZE <%= target.stage_table.name %>;
+VACUUM FULL ANALYZE <%= target.stage_table.name %>;

--- a/spec/masamune/transform/bulk_upsert.dimension_spec.rb
+++ b/spec/masamune/transform/bulk_upsert.dimension_spec.rb
@@ -127,7 +127,7 @@ describe Masamune::Transform::BulkUpsert do
           user_dimension.start_at IS NULL
         ;
 
-        ANALYZE user_dimension;
+        VACUUM FULL ANALYZE user_dimension;
 
         COMMIT;
       EOS
@@ -193,7 +193,7 @@ describe Masamune::Transform::BulkUpsert do
           user_dimension_ledger.start_at IS NULL
         ;
 
-        ANALYZE user_dimension_ledger;
+        VACUUM FULL ANALYZE user_dimension_ledger;
 
         COMMIT;
       EOS

--- a/spec/masamune/transform/define_table.fact_spec.rb
+++ b/spec/masamune/transform/define_table.fact_spec.rb
@@ -198,7 +198,7 @@ describe Masamune::Transform::DefineTable do
         CREATE INDEX visits_file_fact_stage_0fe2101_index ON visits_file_fact_stage (user_agent_type_version, time_key);
         CREATE INDEX visits_file_fact_stage_b0abfed_index ON visits_file_fact_stage (user_dimension_user_id, time_key);
 
-        ANALYZE visits_file_fact_stage;
+        VACUUM FULL ANALYZE visits_file_fact_stage;
       EOS
     end
 

--- a/spec/masamune/transform/define_table.table_spec.rb
+++ b/spec/masamune/transform/define_table.table_spec.rb
@@ -474,7 +474,7 @@ describe Masamune::Transform::DefineTable do
         SELECT 'active'
         WHERE NOT EXISTS (SELECT 1 FROM user_table WHERE name = 'active');
 
-        ANALYZE user_table;
+        VACUUM FULL ANALYZE user_table;
       EOS
     end
   end
@@ -574,7 +574,7 @@ describe Masamune::Transform::DefineTable do
         SELECT default_tenant_id(), -2
         WHERE NOT EXISTS (SELECT 1 FROM user_table WHERE tenant_id = default_tenant_id() AND user_id = -2);
 
-        ANALYZE user_table;
+        VACUUM FULL ANALYZE user_table;
 
         CREATE OR REPLACE FUNCTION default_user_table_user_id()
         RETURNS INTEGER IMMUTABLE AS $$
@@ -902,7 +902,7 @@ describe Masamune::Transform::DefineTable do
         ALTER TABLE user_table ADD CONSTRAINT user_table_3854361_key UNIQUE(tenant_id);
         END IF; END $$;
 
-        ANALYZE user_table;
+        VACUUM FULL ANALYZE user_table;
       EOS
     end
   end
@@ -937,7 +937,7 @@ describe Masamune::Transform::DefineTable do
         CREATE INDEX user_table_e8701ad_index ON user_table (user_id);
         END IF; END $$;
 
-        ANALYZE user_table;
+        VACUUM FULL ANALYZE user_table;
       EOS
     end
   end
@@ -975,7 +975,7 @@ describe Masamune::Transform::DefineTable do
         ALTER TABLE user_table ADD CONSTRAINT user_table_bd2027e_fkey FOREIGN KEY (user_account_state_table_id) REFERENCES user_account_state_table(id);
         END IF; END $$;
 
-        ANALYZE user_table;
+        VACUUM FULL ANALYZE user_table;
       EOS
     end
   end

--- a/spec/masamune/transform/insert_reference_values.dimension_spec.rb
+++ b/spec/masamune/transform/insert_reference_values.dimension_spec.rb
@@ -74,7 +74,7 @@ describe Masamune::Transform::InsertReferenceValues do
           department_type_department_id IS NOT NULL
         ;
 
-        ANALYZE department_type_stage;
+        VACUUM FULL ANALYZE department_type_stage;
 
         BEGIN;
         LOCK TABLE department_type IN EXCLUSIVE MODE;
@@ -96,7 +96,7 @@ describe Masamune::Transform::InsertReferenceValues do
           department_type.department_id IS NULL
         ;
 
-        ANALYZE department_type;
+        VACUUM FULL ANALYZE department_type;
 
         COMMIT;
       EOS

--- a/spec/masamune/transform/insert_reference_values.fact_spec.rb
+++ b/spec/masamune/transform/insert_reference_values.fact_spec.rb
@@ -91,7 +91,7 @@ describe Masamune::Transform::InsertReferenceValues do
           user_agent_type_name IS NOT NULL
         ;
 
-        ANALYZE user_agent_type_stage;
+        VACUUM FULL ANALYZE user_agent_type_stage;
 
         BEGIN;
         LOCK TABLE user_agent_type IN EXCLUSIVE MODE;
@@ -113,7 +113,7 @@ describe Masamune::Transform::InsertReferenceValues do
           user_agent_type.version IS NULL
         ;
 
-        ANALYZE user_agent_type;
+        VACUUM FULL ANALYZE user_agent_type;
 
         COMMIT;
 
@@ -129,7 +129,7 @@ describe Masamune::Transform::InsertReferenceValues do
           feature_type_name IS NOT NULL
         ;
 
-        ANALYZE feature_type_stage;
+        VACUUM FULL ANALYZE feature_type_stage;
 
         BEGIN;
         LOCK TABLE feature_type IN EXCLUSIVE MODE;
@@ -148,7 +148,7 @@ describe Masamune::Transform::InsertReferenceValues do
           feature_type.name IS NULL
         ;
 
-        ANALYZE feature_type;
+        VACUUM FULL ANALYZE feature_type;
 
         COMMIT;
       EOS

--- a/spec/masamune/transform/rollup_fact_spec.rb
+++ b/spec/masamune/transform/rollup_fact_spec.rb
@@ -172,7 +172,7 @@ describe Masamune::Transform::RollupFact do
         CREATE INDEX visits_hourly_fact_y2014m08_d8b1c3e_index ON visits_hourly_fact_y2014m08 (user_agent_type_id);
         CREATE INDEX visits_hourly_fact_y2014m08_39f0fdd_index ON visits_hourly_fact_y2014m08 (user_dimension_id);
 
-        ANALYZE visits_hourly_fact_y2014m08;
+        VACUUM FULL ANALYZE visits_hourly_fact_y2014m08;
 
         COMMIT;
 
@@ -274,7 +274,7 @@ describe Masamune::Transform::RollupFact do
         CREATE INDEX visits_daily_fact_y2014m08_d8b1c3e_index ON visits_daily_fact_y2014m08 (user_agent_type_id);
         CREATE INDEX visits_daily_fact_y2014m08_39f0fdd_index ON visits_daily_fact_y2014m08 (user_dimension_id);
 
-        ANALYZE visits_daily_fact_y2014m08;
+        VACUUM FULL ANALYZE visits_daily_fact_y2014m08;
 
         COMMIT;
 
@@ -376,7 +376,7 @@ describe Masamune::Transform::RollupFact do
         CREATE INDEX visits_monthly_fact_y2014m08_d8b1c3e_index ON visits_monthly_fact_y2014m08 (user_agent_type_id);
         CREATE INDEX visits_monthly_fact_y2014m08_39f0fdd_index ON visits_monthly_fact_y2014m08 (user_dimension_id);
 
-        ANALYZE visits_monthly_fact_y2014m08;
+        VACUUM FULL ANALYZE visits_monthly_fact_y2014m08;
 
         COMMIT;
 

--- a/spec/masamune/transform/stage_dimension_spec.rb
+++ b/spec/masamune/transform/stage_dimension_spec.rb
@@ -110,7 +110,7 @@ describe Masamune::Transform::StageDimension do
           hr_user_account_state_type.name = user_file_dimension_ledger_stage.hr_user_account_state_type_name
         ;
 
-        ANALYZE user_dimension_ledger_stage;
+        VACUUM FULL ANALYZE user_dimension_ledger_stage;
       EOS
     end
   end

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -232,7 +232,7 @@ describe Masamune::Transform::StageFact do
         CREATE INDEX visits_hourly_fact_y2014m08_d8b1c3e_index ON visits_hourly_fact_y2014m08 (user_agent_type_id);
         CREATE INDEX visits_hourly_fact_y2014m08_39f0fdd_index ON visits_hourly_fact_y2014m08 (user_dimension_id);
 
-        ANALYZE visits_hourly_fact_y2014m08;
+        VACUUM FULL ANALYZE visits_hourly_fact_y2014m08;
 
         COMMIT;
 


### PR DESCRIPTION
VACUUM FULL helped to reduce the USER_DIMENSION table size, improved reports performance by reducing IO.

Replaced ANALYZE in ETL with VACUUM FULL ANALYZE. Quick test shows the largest table USER_DIMENSION takes a minute.