### PR TITLE
Add Postgres retries / backoff

### DIFF
--- a/lib/masamune/actions/elastic_mapreduce.rb
+++ b/lib/masamune/actions/elastic_mapreduce.rb
@@ -32,7 +32,7 @@ module Masamune::Actions
 
       command = Masamune::Commands::Interactive.new(environment, :interactive => opts.fetch(:interactive, false))
       command = Masamune::Commands::ElasticMapReduce.new(command, opts)
-      command = Masamune::Commands::RetryWithBackoff.new(command, opts)
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.elastic_mapreduce.slice(:retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.interactive? ? command.replace : command.execute

--- a/lib/masamune/actions/hadoop_filesystem.rb
+++ b/lib/masamune/actions/hadoop_filesystem.rb
@@ -30,7 +30,7 @@ module Masamune::Actions
       opts.merge!(block: block.to_proc) if block_given?
 
       command = Masamune::Commands::HadoopFilesystem.new(environment, opts)
-      command = Masamune::Commands::RetryWithBackoff.new(command, opts)
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.hadoop_filesystem.slice(:retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.execute

--- a/lib/masamune/actions/hadoop_streaming.rb
+++ b/lib/masamune/actions/hadoop_streaming.rb
@@ -32,7 +32,7 @@ module Masamune::Actions
       end
 
       command = Masamune::Commands::ElasticMapReduce.new(command, opts.except(:extra)) if configuration.elastic_mapreduce[:jobflow]
-      command = Masamune::Commands::RetryWithBackoff.new(command, opts)
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.hadoop_streaming.slice(:retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.execute

--- a/lib/masamune/actions/hive.rb
+++ b/lib/masamune/actions/hive.rb
@@ -36,7 +36,7 @@ module Masamune::Actions
 
       command = Masamune::Commands::Hive.new(environment, opts)
       command = Masamune::Commands::ElasticMapReduce.new(command, opts.except(:extra)) if configuration.elastic_mapreduce[:jobflow]
-      command = Masamune::Commands::RetryWithBackoff.new(command, opts)
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.hive.slice(:retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.interactive? ? command.replace : command.execute

--- a/lib/masamune/actions/postgres.rb
+++ b/lib/masamune/actions/postgres.rb
@@ -36,7 +36,7 @@ module Masamune::Actions
       opts.merge!(block: block.to_proc) if block_given?
 
       command = Masamune::Commands::Postgres.new(environment, opts)
-      command = Masamune::Commands::RetryWithBackoff.new(command, opts)
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.postgres.slice(:retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.interactive? ? command.replace : command.execute

--- a/lib/masamune/actions/postgres.rb
+++ b/lib/masamune/actions/postgres.rb
@@ -36,6 +36,7 @@ module Masamune::Actions
       opts.merge!(block: block.to_proc) if block_given?
 
       command = Masamune::Commands::Postgres.new(environment, opts)
+      command = Masamune::Commands::RetryWithBackoff.new(command, opts)
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.interactive? ? command.replace : command.execute

--- a/lib/masamune/actions/s3cmd.rb
+++ b/lib/masamune/actions/s3cmd.rb
@@ -31,7 +31,7 @@ module Masamune::Actions
       opts.merge!(block: block.to_proc) if block_given?
 
       command = Masamune::Commands::S3Cmd.new(environment, opts)
-      command = Masamune::Commands::RetryWithBackoff.new(command, opts)
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.s3cmd.slice(:retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.execute

--- a/lib/masamune/tasks/postgres_thor.rb
+++ b/lib/masamune/tasks/postgres_thor.rb
@@ -38,9 +38,11 @@ module Masamune::Tasks
     method_option :exec, :aliases => '-e', :desc => 'SQL from command line'
     method_option :output, :aliases => '-o', :desc => 'Save SQL output to file'
     method_option :csv, :type => :boolean, :desc => 'Report SQL output in CSV format', :default => false
+    method_option :retry, :type => :boolean, :desc => 'Retry SQL query in event of failure', :default => false
     def psql_exec
       postgres_options = options.dup.with_indifferent_access
       postgres_options.merge!(print: true)
+      postgres_options.merge!(retries: 0) unless options[:retry]
       postgres(postgres_options)
     end
     default_task :psql_exec

--- a/spec/masamune/actions/elastic_mapreduce_spec.rb
+++ b/spec/masamune/actions/elastic_mapreduce_spec.rb
@@ -48,6 +48,15 @@ describe Masamune::Actions::ElasticMapreduce do
     subject { instance.elastic_mapreduce }
 
     it { is_expected.to be_success }
+
+    context 'with retries and backoff' do
+      before do
+        allow(instance).to receive_message_chain(:configuration, :elastic_mapreduce).and_return(retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+      end
+
+      it { is_expected.to be_success }
+    end
   end
 
   describe '.after_initialize' do

--- a/spec/masamune/actions/hadoop_filesystem_spec.rb
+++ b/spec/masamune/actions/hadoop_filesystem_spec.rb
@@ -40,5 +40,14 @@ describe Masamune::Actions::HadoopFilesystem do
     subject { instance.hadoop_filesystem }
 
     it { is_expected.to be_success }
+
+    context 'with retries and backoff' do
+      before do
+        allow(instance).to receive_message_chain(:configuration, :hadoop_filesystem).and_return(retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+      end
+
+      it { is_expected.to be_success }
+    end
   end
 end

--- a/spec/masamune/actions/hive_spec.rb
+++ b/spec/masamune/actions/hive_spec.rb
@@ -65,6 +65,15 @@ describe Masamune::Actions::Hive do
 
       it { is_expected.to be_success }
     end
+
+    context 'with retries and backoff' do
+      before do
+        allow(instance).to receive_message_chain(:configuration, :hive).and_return(retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+      end
+
+      it { is_expected.to be_success }
+    end
   end
 
   describe '.after_initialize' do

--- a/spec/masamune/actions/postgres_spec.rb
+++ b/spec/masamune/actions/postgres_spec.rb
@@ -55,6 +55,15 @@ describe Masamune::Actions::Postgres do
     subject { instance.postgres }
 
     it { is_expected.to be_success }
+
+    context 'with retries and backoff' do
+      before do
+        allow(instance).to receive_message_chain(:configuration, :postgres).and_return(retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+      end
+
+      it { is_expected.to be_success }
+    end
   end
 
   describe '.after_initialize' do

--- a/spec/masamune/actions/s3cmd_spec.rb
+++ b/spec/masamune/actions/s3cmd_spec.rb
@@ -40,5 +40,14 @@ describe Masamune::Actions::S3Cmd do
     subject { instance.s3cmd 'ls', 's3://fake-bucket' }
 
     it { is_expected.to be_success }
+
+    context 'with retries and backoff' do
+      before do
+        allow(instance).to receive_message_chain(:configuration, :s3cmd).and_return(retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+      end
+
+      it { is_expected.to be_success }
+    end
   end
 end

--- a/spec/masamune/tasks/hive_thor_spec.rb
+++ b/spec/masamune/tasks/hive_thor_spec.rb
@@ -34,6 +34,15 @@ describe Masamune::Tasks::HiveThor do
     it_behaves_like 'command usage'
   end
 
+  context 'without arguments' do
+    let(:options) { [] }
+
+    it do
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_including(retries: 0)).once.and_return(mock_success)
+      cli_invocation
+    end
+  end
+
   context 'with --file and --initialize' do
     let(:options) { ['--file=zombo.hql', '--initialize'] }
     it do
@@ -72,6 +81,14 @@ describe Masamune::Tasks::HiveThor do
     let(:options) { ['-X', 'YEAR:2015', 'MONTH:1'] }
     it do
       expect_any_instance_of(described_class).to receive(:hive).with(hash_including(variables: { 'YEAR' => '2015', 'MONTH' => '1'})).once.and_return(mock_success)
+      cli_invocation
+    end
+  end
+
+  context 'with --retry' do
+    let(:options) { ['--retry'] }
+    it do
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_excluding(retries: 0)).once.and_return(mock_success)
       cli_invocation
     end
   end

--- a/spec/masamune/tasks/postgres_thor_spec.rb
+++ b/spec/masamune/tasks/postgres_thor_spec.rb
@@ -31,6 +31,15 @@ describe Masamune::Tasks::PostgresThor do
     it_behaves_like 'command usage'
   end
 
+  context 'without arguments' do
+    let(:options) { [] }
+
+    it do
+      expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(retries: 0)).once.and_return(mock_success)
+      cli_invocation
+    end
+  end
+
   context 'with --file and --initialize' do
     let(:options) { ['--file=zombo.hql', '--initialize'] }
     it do
@@ -44,6 +53,14 @@ describe Masamune::Tasks::PostgresThor do
     let(:options) { ['--file=zombo.hql'] }
     it do
       expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(file: 'zombo.hql')).once.and_return(mock_success)
+      cli_invocation
+    end
+  end
+
+  context 'with --retry' do
+    let(:options) { ['--retry'] }
+    it do
+      expect_any_instance_of(described_class).to receive(:postgres).with(hash_excluding(retries: 0)).once.and_return(mock_success)
       cli_invocation
     end
   end


### PR DESCRIPTION
- Also allow per command `retries` & `backoff` configuration

From CLI:
```
% masamune-psql -d -e 'SHOULD FAIL'
D, [2015-10-07T14:52:09.593788 #57731] DEBUG -- : ["psql", "--host=localhost", "--dbname=masamune", "--username=mandrews", "--no-password", "--command=SHOULD FAIL;"]
D, [2015-10-07T14:52:09.607699 #57731] DEBUG -- : ERROR:  syntax error at or near "SHOULD"
D, [2015-10-07T14:52:09.607812 #57731] DEBUG -- : LINE 1: SHOULD FAIL;
D, [2015-10-07T14:52:09.607843 #57731] DEBUG -- :         ^
D, [2015-10-07T14:52:09.608234 #57731] DEBUG -- : #<Process::Status: pid 57733 exit 1>
E, [2015-10-07T14:52:09.608603 #57731] ERROR -- : exited with code: 1
D, [2015-10-07T14:52:14.612135 #57731] DEBUG -- : max retries (0) attempted, bailing
E, [2015-10-07T14:52:14.612558 #57731] ERROR -- : fail_fast: psql --host=localhost --dbname=masamune --username=mandrews --no-password --command=SHOULD FAIL; (RuntimeError) backtrace:
...
```

```
% masamune-psql -d -e 'SHOULD RETRY' --retry
D, [2015-10-07T14:53:32.216790 #57939] DEBUG -- : ["psql", "--host=localhost", "--dbname=masamune", "--username=mandrews", "--no-password", "--command=SHOULD RETRY;"]
D, [2015-10-07T14:53:32.231049 #57939] DEBUG -- : ERROR:  syntax error at or near "SHOULD"
D, [2015-10-07T14:53:32.231150 #57939] DEBUG -- : LINE 1: SHOULD RETRY;
D, [2015-10-07T14:53:32.231182 #57939] DEBUG -- :         ^
D, [2015-10-07T14:53:32.231576 #57939] DEBUG -- : #<Process::Status: pid 57941 exit 1>
E, [2015-10-07T14:53:32.232061 #57939] ERROR -- : exited with code: 1
D, [2015-10-07T14:53:37.235341 #57939] DEBUG -- : retrying (1/3)
D, [2015-10-07T14:53:37.252035 #57939] DEBUG -- : ERROR:  syntax error at or near "SHOULD"
D, [2015-10-07T14:53:37.252138 #57939] DEBUG -- : LINE 1: SHOULD RETRY;
D, [2015-10-07T14:53:37.252171 #57939] DEBUG -- :         ^
D, [2015-10-07T14:53:37.252630 #57939] DEBUG -- : #<Process::Status: pid 57944 exit 1>
E, [2015-10-07T14:53:37.252923 #57939] ERROR -- : exited with code: 1
D, [2015-10-07T14:53:42.256780 #57939] DEBUG -- : retrying (2/3)
D, [2015-10-07T14:53:42.273773 #57939] DEBUG -- : ERROR:  syntax error at or near "SHOULD"
D, [2015-10-07T14:53:42.273879 #57939] DEBUG -- : LINE 1: SHOULD RETRY;
D, [2015-10-07T14:53:42.273926 #57939] DEBUG -- :         ^
D, [2015-10-07T14:53:42.274371 #57939] DEBUG -- : #<Process::Status: pid 57946 exit 1>
E, [2015-10-07T14:53:42.274744 #57939] ERROR -- : exited with code: 1
D, [2015-10-07T14:53:47.275358 #57939] DEBUG -- : retrying (3/3)
D, [2015-10-07T14:53:47.292427 #57939] DEBUG -- : ERROR:  syntax error at or near "SHOULD"
D, [2015-10-07T14:53:47.292540 #57939] DEBUG -- : LINE 1: SHOULD RETRY;
D, [2015-10-07T14:53:47.292566 #57939] DEBUG -- :         ^
D, [2015-10-07T14:53:47.292939 #57939] DEBUG -- : #<Process::Status: pid 57949 exit 1>
E, [2015-10-07T14:53:47.293353 #57939] ERROR -- : exited with code: 1
D, [2015-10-07T14:53:52.293770 #57939] DEBUG -- : max retries (3) attempted, bailing
E, [2015-10-07T14:53:52.294353 #57939] ERROR -- : fail_fast: psql --host=localhost --dbname=masamune --username=mandrews --no-password --command=SHOULD RETRY; (RuntimeError) backtrace:
...
```