### PR TITLE
Skip postgres retry for initialization queries

### DIFF
--- a/lib/masamune/actions/postgres.rb
+++ b/lib/masamune/actions/postgres.rb
@@ -51,14 +51,14 @@ module Masamune::Actions
     def load_postgres_setup_files
       configuration.postgres[:setup_files].each do |file|
         configuration.with_quiet do
-          postgres(file: file)
+          postgres(file: file, retries: 0)
         end
       end if configuration.postgres.has_key?(:setup_files)
     end
 
     def load_postgres_schema
       transform = define_schema(catalog, :postgres)
-      postgres(file: transform.to_file)
+      postgres(file: transform.to_file, retries: 0)
     rescue => e
       logger.error(e)
       logger.error("Could not load schema")

--- a/lib/masamune/helpers/postgres.rb
+++ b/lib/masamune/helpers/postgres.rb
@@ -39,7 +39,7 @@ module Masamune::Helpers
     end
 
     def database_exists?
-      @database_exists ||= postgres(exec: 'SELECT version();', fail_fast: false).success?
+      @database_exists ||= postgres(exec: 'SELECT version();', fail_fast: false, retries: 0).success?
     end
 
     def table_exists?(table)
@@ -64,7 +64,7 @@ module Masamune::Helpers
 
     def update_tables
       return unless @cache.empty?
-      postgres(exec: 'SELECT table_name FROM information_schema.tables;', tuple_output: true) do |line|
+      postgres(exec: 'SELECT table_name FROM information_schema.tables;', tuple_output: true, retries: 0) do |line|
         table = line.strip
         next if table =~ /\Apg_/
         @cache[table] ||= nil
@@ -73,7 +73,7 @@ module Masamune::Helpers
 
     def update_table_last_modified_at(table, column)
       return if @cache[table].present?
-      postgres(exec: "SELECT MAX(#{column}) FROM #{table};", tuple_output: true) do |line|
+      postgres(exec: "SELECT MAX(#{column}) FROM #{table};", tuple_output: true, retries: 0) do |line|
         begin
           @cache[table] = Time.parse(line.strip).at_beginning_of_minute.utc
         rescue ArgumentError

--- a/spec/masamune/actions/postgres_spec.rb
+++ b/spec/masamune/actions/postgres_spec.rb
@@ -90,7 +90,7 @@ describe Masamune::Actions::Postgres do
       before do
         expect(postgres_helper).to receive(:database_exists?).and_return(false)
         expect(instance).to receive(:postgres_admin).with(action: :create, database: 'test', safe: true).once
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql').once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
         after_initialize_invoke
       end
       it 'should call posgres_admin once' do; end
@@ -100,7 +100,7 @@ describe Masamune::Actions::Postgres do
       before do
         expect(postgres_helper).to receive(:database_exists?).and_return(true)
         expect(instance).to receive(:postgres_admin).never
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql').once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
         after_initialize_invoke
       end
       it 'should not call postgres_admin' do; end
@@ -110,8 +110,8 @@ describe Masamune::Actions::Postgres do
       let(:setup_files) { ['setup.psql'] }
       before do
         expect(postgres_helper).to receive(:database_exists?).and_return(true)
-        expect(instance).to receive(:postgres).with(file: setup_files.first).once
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql').once
+        expect(instance).to receive(:postgres).with(file: setup_files.first, retries: 0).once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
         after_initialize_invoke
       end
       it 'should call postgres with setup_files' do; end
@@ -133,7 +133,7 @@ describe Masamune::Actions::Postgres do
       before do
         filesystem.touch!('schema_1.psql', 'schema_2.psql')
         expect(postgres_helper).to receive(:database_exists?).and_return(true)
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql').once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
         after_initialize_invoke
       end
       it 'should call postgres with schema_files' do; end
@@ -144,7 +144,7 @@ describe Masamune::Actions::Postgres do
       before do
         filesystem.touch!('schema.rb')
         expect(postgres_helper).to receive(:database_exists?).and_return(true)
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql').once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
         after_initialize_invoke
       end
       it 'should call postgres with schema_files' do; end

--- a/spec/masamune/tasks/postgres_thor_spec.rb
+++ b/spec/masamune/tasks/postgres_thor_spec.rb
@@ -43,7 +43,7 @@ describe Masamune::Tasks::PostgresThor do
   context 'with --file and --initialize' do
     let(:options) { ['--file=zombo.hql', '--initialize'] }
     it do
-      expect_any_instance_of(described_class).to receive(:postgres).with(file: instance_of(String)).once.and_return(mock_success)
+      expect_any_instance_of(described_class).to receive(:postgres).with(file: instance_of(String), retries: 0).once.and_return(mock_success)
       expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(file: 'zombo.hql')).once.and_return(mock_success)
       cli_invocation
     end


### PR DESCRIPTION
While running some integration tests I noticed they were running a bit slower.  Postgres initialization is issuing several queries to check database, table existence and these queries are expected to fail under normal conditions so retry is unnecessary.

Before:
```
% masamune-psql -d --init
D, [2015-10-07T15:51:42.840338 #97271] DEBUG -- : ["psql", "--host=localhost", "--dbname=masamune", "--username=mandrews", "--no-password", "--command=SELECT version();"]
D, [2015-10-07T15:51:42.852222 #97271] DEBUG -- : psql: FATAL:  database "masamune" does not exist
D, [2015-10-07T15:51:42.852779 #97271] DEBUG -- : #<Process::Status: pid 97280 exit 2>
E, [2015-10-07T15:51:42.853348 #97271] ERROR -- : exited with code: 2
D, [2015-10-07T15:51:47.858249 #97271] DEBUG -- : retrying (1/3)
D, [2015-10-07T15:51:47.868666 #97271] DEBUG -- : psql: FATAL:  database "masamune" does not exist
D, [2015-10-07T15:51:47.869111 #97271] DEBUG -- : #<Process::Status: pid 98482 exit 2>
E, [2015-10-07T15:51:47.869539 #97271] ERROR -- : exited with code: 2
D, [2015-10-07T15:51:52.869900 #97271] DEBUG -- : retrying (2/3)
D, [2015-10-07T15:51:52.881996 #97271] DEBUG -- : psql: FATAL:  database "masamune" does not exist
D, [2015-10-07T15:51:52.882596 #97271] DEBUG -- : #<Process::Status: pid 98535 exit 2>
E, [2015-10-07T15:51:52.882913 #97271] ERROR -- : exited with code: 2
D, [2015-10-07T15:51:57.885945 #97271] DEBUG -- : retrying (3/3)
D, [2015-10-07T15:51:57.898728 #97271] DEBUG -- : psql: FATAL:  database "masamune" does not exist
D, [2015-10-07T15:51:57.899257 #97271] DEBUG -- : #<Process::Status: pid 98592 exit 2>
E, [2015-10-07T15:51:57.899646 #97271] ERROR -- : exited with code: 2
D, [2015-10-07T15:52:02.902918 #97271] DEBUG -- : max retries (3) attempted, bailing
D, [2015-10-07T15:52:02.903307 #97271] DEBUG -- : ["createdb", "--host=localhost", "--username=mandrews", "--no-password", "masamune"]
D, [2015-10-07T15:52:03.157375 #97271] DEBUG -- : #<Process::Status: pid 99775 exit 0>
D, [2015-10-07T15:52:03.160933 #97271] DEBUG -- : ["psql", "--host=localhost", "--dbname=masamune", "--username=mandrews", "--no-password", "--file=/var/folders/4l/qnyn1jwx57vbwvjz1
y2l7g3h0000gn/T/masamune20151007-97271-zwkrze"]
I, [2015-10-07T15:52:03.161068 #97271]  INFO -- : psql with file /var/folders/4l/qnyn1jwx57vbwvjz1y2l7g3h0000gn/T/masamune20151007-97271-zwkrze
D, [2015-10-07T15:52:03.207936 #97271] DEBUG -- : #<Process::Status: pid 99798 exit 0>
D, [2015-10-07T15:52:03.208856 #97271] DEBUG -- : replace: psql --host=localhost --dbname=masamune --username=mandrews --no-password
D, [2015-10-07T15:52:03.208941 #97271] DEBUG -- : ["psql", "--host=localhost", "--dbname=masamune", "--username=mandrews", "--no-password"]
psql (9.4.4)
Type "help" for help.

masamune=# \q
```

After:
```
% masamune-psql -d --init
D, [2015-10-07T15:52:57.399541 #4201] DEBUG -- : ["psql", "--host=localhost", "--dbname=masamune", "--username=mandrews", "--no-password", "--command=SELECT version();"]
D, [2015-10-07T15:52:57.412527 #4201] DEBUG -- : psql: FATAL:  database "masamune" does not exist
D, [2015-10-07T15:52:57.413132 #4201] DEBUG -- : #<Process::Status: pid 4203 exit 2>
E, [2015-10-07T15:52:57.413613 #4201] ERROR -- : exited with code: 2
D, [2015-10-07T15:53:02.417821 #4201] DEBUG -- : max retries (0) attempted, bailing
D, [2015-10-07T15:53:02.418192 #4201] DEBUG -- : ["createdb", "--host=localhost", "--username=mandrews", "--no-password", "masamune"]
D, [2015-10-07T15:53:02.664426 #4201] DEBUG -- : #<Process::Status: pid 4265 exit 0>
D, [2015-10-07T15:53:02.667698 #4201] DEBUG -- : ["psql", "--host=localhost", "--dbname=masamune", "--username=mandrews", "--no-password", "--file=/var/folders/4l/qnyn1jwx57vbwvjz1y2l7g3h0000gn/T/masamune20151007-4201-jzcc7z"]
I, [2015-10-07T15:53:02.667794 #4201]  INFO -- : psql with file /var/folders/4l/qnyn1jwx57vbwvjz1y2l7g3h0000gn/T/masamune20151007-4201-jzcc7z
D, [2015-10-07T15:53:02.716242 #4201] DEBUG -- : #<Process::Status: pid 4330 exit 0>
D, [2015-10-07T15:53:02.717773 #4201] DEBUG -- : replace: psql --host=localhost --dbname=masamune --username=mandrews --no-password
D, [2015-10-07T15:53:02.717827 #4201] DEBUG -- : ["psql", "--host=localhost", "--dbname=masamune", "--username=mandrews", "--no-password"]
psql (9.4.4)
Type "help" for help.

masamune=# \q
```