### PR TITLE
Write hive exec string to temporary file

### DIFF
--- a/lib/masamune/commands/hive.rb
+++ b/lib/masamune/commands/hive.rb
@@ -41,7 +41,6 @@ module Masamune::Commands
       :schema_files   => [],
       :file           => nil,
       :exec           => nil,
-      :input          => nil,
       :output         => nil,
       :print          => false,
       :block          => nil,
@@ -57,12 +56,6 @@ module Masamune::Commands
       super delegate
       DEFAULT_ATTRIBUTES.merge(configuration.hive).merge(attrs).each do |name, value|
         instance_variable_set("@#{name}", value)
-      end
-    end
-
-    def stdin
-      if @input || @exec
-        @stdin ||= StringIO.new(strip_sql(@input || @exec))
       end
     end
 
@@ -99,6 +92,7 @@ module Masamune::Commands
 
       if @exec
         console("hive exec '#{strip_sql(@exec)}' #{'into ' + @output if @output}")
+        @file = exec_file
       end
 
       if @output
@@ -173,6 +167,13 @@ module Masamune::Commands
 
     def remote_file
       @remote_file ||= File.join(filesystem.mktempdir!(:tmp_dir), filesystem.basename(@file)).gsub(/.erb\z/,'')
+    end
+
+    def exec_file
+      Tempfile.new('masamune').tap do |tmp|
+        tmp.write(@exec)
+        tmp.flush
+      end.path
     end
   end
 end

--- a/spec/support/masamune/shared_example_group.rb
+++ b/spec/support/masamune/shared_example_group.rb
@@ -128,12 +128,7 @@ module Masamune::SharedExampleGroup
 
   def execute_output_command(output, output_file)
     if output['hive'] && output['hive'].is_a?(String)
-      # FIXME: Replace with exec once SBI-530 is fixed
-      Tempfile.open('etl') do |tmp|
-        tmp.write(output['hive'])
-        tmp.flush
-        hive(file: tmp.path, output: output_file)
-      end
+      hive(exec: output['hive'], output: output_file)
     elsif output['table']
       table = eval "catalog.#{output['table']}"
       query = denormalize_table(table, output.slice('columns', 'order', 'except', 'include')).to_s
@@ -142,12 +137,7 @@ module Masamune::SharedExampleGroup
       when :postgres
         postgres(exec: query, csv: true, output: output_file)
       when :hive
-        # FIXME: Replace with exec once SBI-530 is fixed
-        Tempfile.open('etl') do |tmp|
-          tmp.write(query)
-          tmp.flush
-          hive(file: tmp.path, output: output_file)
-        end
+        hive(exec: query, output: output_file)
       else
         raise "'table' output not supported for #{output['table']}"
       end


### PR DESCRIPTION
`hive(exec: STRING)` with a string larger than `PIPE_BUF` gets truncated. This fixes the issue by writing exec string to temporary file and uses this for execution