### PR TITLE
Add back DataFlow to Shell

### DIFF
--- a/lib/masamune/actions/data_flow.rb
+++ b/lib/masamune/actions/data_flow.rb
@@ -73,6 +73,11 @@ module Masamune::Actions
       engine.execute(current_command_name, options)
     end
 
+    def reset_module!
+      ClassMethods.reset_module!
+    end
+    module_function :reset_module!
+
     private
 
     included do |base|
@@ -94,27 +99,26 @@ module Masamune::Actions
     end
 
     module ClassMethods
-      @@namespaces = []
-      @@commands = []
-      @@sources = []
-      @@targets = []
-
       def skip
+        initialize_module!
         @@namespaces << namespace
         @@sources << {skip: true}
         @@targets << {skip: true}
       end
 
       def source(source_options = {})
+        initialize_module!
         @@namespaces << namespace
         @@sources << source_options
       end
 
       def target(target_options = {})
+        initialize_module!
         @@targets << target_options
       end
 
       def create_command(*a)
+        initialize_module!
         super.tap do
           @@commands += a
         end
@@ -125,6 +129,22 @@ module Masamune::Actions
       end
 
       private
+
+      def reset_module!
+        @@namespaces = []
+        @@targets = []
+        @@sources = []
+        @@commands = []
+        @@engine = nil
+      end
+      module_function :reset_module!
+
+      def initialize_module!
+        @@namespaces ||= []
+        @@targets ||= []
+        @@sources ||= []
+        @@commands ||= []
+      end
 
       # If internal call to Thor::Base.start fails, exit
       def exit_on_failure?

--- a/lib/masamune/tasks/shell_thor.rb
+++ b/lib/masamune/tasks/shell_thor.rb
@@ -27,7 +27,7 @@ require 'pry'
 module Masamune::Tasks
   class ShellThor < Thor
     include Masamune::Thor
-    include Masamune::Actions::DateParse
+    include Masamune::Actions::DataFlow
 
     # FIXME need to add an unnecessary namespace until this issue is fixed:
     # https://github.com/wycats/thor/pull/247
@@ -35,6 +35,7 @@ module Masamune::Tasks
     skip_lock!
 
     desc 'shell', 'Launch an interactive shell'
+    skip
     method_option :prompt, :desc => 'Set shell prompt', :default => 'masamune'
     class_option :start, :aliases => '-a', :desc => 'Start time', default: '1 month ago'
     def shell_exec

--- a/spec/masamune/tasks/shell_thor_spec.rb
+++ b/spec/masamune/tasks/shell_thor_spec.rb
@@ -34,4 +34,8 @@ describe Masamune::Tasks::ShellThor do
       cli_invocation
     end
   end
+
+  context 'includes reference to engine' do
+    it { expect(described_class.engine).to_not be_nil }
+  end
 end

--- a/spec/support/rspec/example/task_example_group.rb
+++ b/spec/support/rspec/example/task_example_group.rb
@@ -72,6 +72,7 @@ module TaskExampleGroup
   def self.included(base)
     base.before :all do
       ENV['THOR_DEBUG'] = '1'
+      Masamune::Actions::DataFlow.reset_module!
     end
 
     base.let(:thor_class) { described_class }


### PR DESCRIPTION
It's helpful to have a reference to the constructed `DataPlan::Engine` for debugging:
```
± % bundle exec masamune-shell 
masamune> engine
=> #<Masamune::DataPlan::Engine:0x007fce349b01b8
 @command_rules={},
 @current_depth=0,
 @environment=
  #<Masamune::Environment:0x007fce3199ae38
   @configuration=
    #<Masamune::Configuration:0x007fce319707c8
     @backoff=5,
     @debug=false,
     @dry_run=false,
     @elastic_mapreduce=
      {"path"=>"elastic-mapreduce",
       "jobflows"=>{"build"=>"j-BUILD"},
       "templates"=>{"list_with_state"=>{"command"=>"--list --state %state", "default"=>{"state"=>"RUNNING"}}},
       "enabled"=>false,
       "options"=>[{"--credentials"=>"/Users/mandrews/.amazon/credentials.json"}]},
     @environment=#<Masamune::Environment:0x007fce3199ae38 ...>,
     @hadoop_filesystem={},
     @hadoop_streaming={},
     ...
```