### PR TITLE
Memoize command_args_for_file to limit unecessary copy_file_to_file

### DIFF
--- a/lib/masamune/commands/hive.rb
+++ b/lib/masamune/commands/hive.rb
@@ -144,7 +144,7 @@ module Masamune::Commands
     end
 
     def command_args_for_file
-      @file =~ /\.erb\Z/ ? command_args_for_template : command_args_for_simple_file
+      @command_args_for_file ||= (@file =~ /\.erb\Z/ ? command_args_for_template : command_args_for_simple_file)
     end
 
     def command_args_for_simple_file


### PR DESCRIPTION
This function is getting called multiple times and copies a local file to the remote as a side effect. Memoizing ensures this only happens once