### PR TITLE
Only evaluate template if file is a template

### DIFF
--- a/lib/masamune/commands/hive.rb
+++ b/lib/masamune/commands/hive.rb
@@ -144,7 +144,7 @@ module Masamune::Commands
     end
 
     def command_args_for_file
-      @command_args_for_file ||= (@file =~ /\.erb\Z/ ? command_args_for_template : command_args_for_simple_file)
+      @command_args_for_file ||= (template_file? ? command_args_for_template : command_args_for_simple_file)
     end
 
     def command_args_for_simple_file
@@ -163,6 +163,10 @@ module Masamune::Commands
 
     private
 
+    def template_file?
+      @file =~ /\.erb\Z/
+    end
+
     def remote_file
       @remote_file ||= File.join(filesystem.mktempdir!(:tmp_dir), filesystem.basename(@file)).gsub(/.erb\z/,'')
     end
@@ -175,6 +179,7 @@ module Masamune::Commands
     end
 
     def rendered_template
+      return unless template_file?
       @rendered_template ||= Masamune::Template.render_to_file(@file, @variables)
     end
   end

--- a/lib/masamune/commands/postgres.rb
+++ b/lib/masamune/commands/postgres.rb
@@ -115,8 +115,12 @@ module Masamune::Commands
 
     private
 
+    def template_file?
+      @file =~ /\.erb\Z/
+    end
+
     def command_args_for_file
-      @file =~ /\.erb\Z/ ? command_args_for_template : command_args_for_simple_file
+      template_file? ? command_args_for_template : command_args_for_simple_file
     end
 
     def command_args_for_simple_file
@@ -139,6 +143,7 @@ module Masamune::Commands
     end
 
     def rendered_template
+      return unless template_file?
       @rendered_template ||= Masamune::Template.render_to_file(@file, @variables)
     end
   end

--- a/spec/masamune/commands/hive_spec.rb
+++ b/spec/masamune/commands/hive_spec.rb
@@ -64,6 +64,15 @@ describe Masamune::Commands::Hive do
       it { is_expected.to eq([*default_command, '-f', remote_file]) }
     end
 
+    context 'with file and debug' do
+      let(:attrs) { {file: local_file, debug: true} }
+      before do
+        expect(File).to receive(:read).with(local_file).and_return('SHOW TABLES;')
+        expect(instance.logger).to receive(:debug).with("#{local_file}:\nSHOW TABLES;")
+      end
+      it { is_expected.to eq([*default_command, '-f', remote_file]) }
+    end
+
     context 'with exec' do
       let(:attrs) { {exec: 'SELECT * FROM table;'} }
       before do

--- a/spec/masamune/commands/postgres_spec.rb
+++ b/spec/masamune/commands/postgres_spec.rb
@@ -76,6 +76,15 @@ describe Masamune::Commands::Postgres do
       it { is_expected.to eq([*default_command, '--file=zomg.psql']) }
     end
 
+    context 'with file and debug' do
+      let(:attrs) { {file: 'zomg.psql', debug: true} }
+      before do
+        expect(File).to receive(:read).with('zomg.psql').and_return('SHOW TABLES;')
+        expect(instance.logger).to receive(:debug).with("zomg.psql:\nSHOW TABLES;")
+      end
+      it { is_expected.to eq([*default_command, '--file=zomg.psql']) }
+    end
+
     context 'with file and exec' do
       let(:attrs) { {file: 'zomg.psql', exec: 'SELECT * FROM table;'} }
       it { expect { subject }.to raise_error(/Cannot specify both file and exec/) }


### PR DESCRIPTION
The code is trying to render the file as a template for `:debug` output even if the file is not a template:
```
$ masamune-psql -f wtf.psql -d
I, [2016-02-05T21:31:45.950169 #42911]  INFO -- : psql with file wtf.psql
...
No template engine registered for wtf.psql
For complete debug log see: /opt/var/log/XXX/1454707905-42911.log
```