### PR TITLE
More fail fast

### DIFF
--- a/examples/apache_log/spec/task_spec.rb
+++ b/examples/apache_log/spec/task_spec.rb
@@ -29,6 +29,9 @@ describe ApacheLogTask do
     include_context 'task_fixture', fixture: 'load_users' do
       let(:command) { 'load_users' }
       let(:options) { ['--start', '2015-10-01', '--stop', '2015-10-02'] }
+      before do
+        execute_command
+      end
     end
   end
 
@@ -36,11 +39,14 @@ describe ApacheLogTask do
     include_context 'task_fixture', fixture: 'extract_logs' do
       let(:command) { 'extract_logs' }
       let(:options) { ['--start', '2015-10-01', '--stop', '2015-10-02'] }
+      before do
+        execute_command
+      end
     end
   end
 
   describe 'load_visits' do
-    include_context 'task_fixture', fixture: 'load_visits', execute_command: false do
+    include_context 'task_fixture', fixture: 'load_visits' do
       let(:command) { 'load_visits' }
       let(:options) { ['--start', '2015-10-01', '--stop', '2015-10-02'] }
       before do

--- a/examples/apache_log/spec/task_spec.rb
+++ b/examples/apache_log/spec/task_spec.rb
@@ -29,9 +29,6 @@ describe ApacheLogTask do
     include_context 'task_fixture', fixture: 'load_users' do
       let(:command) { 'load_users' }
       let(:options) { ['--start', '2015-10-01', '--stop', '2015-10-02'] }
-      before do
-        execute_command
-      end
     end
   end
 
@@ -39,14 +36,11 @@ describe ApacheLogTask do
     include_context 'task_fixture', fixture: 'extract_logs' do
       let(:command) { 'extract_logs' }
       let(:options) { ['--start', '2015-10-01', '--stop', '2015-10-02'] }
-      before do
-        execute_command
-      end
     end
   end
 
   describe 'load_visits' do
-    include_context 'task_fixture', fixture: 'load_visits' do
+    include_context 'task_fixture', fixture: 'load_visits', execute_command: false do
       let(:command) { 'load_visits' }
       let(:options) { ['--start', '2015-10-01', '--stop', '2015-10-02'] }
       before do

--- a/lib/masamune/actions/transform.rb
+++ b/lib/masamune/actions/transform.rb
@@ -46,33 +46,33 @@ module Masamune::Actions
 
     FILE_MODE = 0777 - File.umask
 
-    def load_dimension(source_files, source, target)
+    def load_dimension(source_files, source, target, options = {})
       optional_apply_map(source_files, source, target) do |intermediate_files, intermediate|
         transform = Wrapper.load_dimension(intermediate_files, intermediate, target)
-        postgres file: transform.to_file, debug: (source.debug || target.debug || intermediate.debug)
+        postgres file: transform.to_file, debug: (source.debug || target.debug || intermediate.debug), **options
       end
     end
 
-    def consolidate_dimension(target)
+    def consolidate_dimension(target, options = {})
       transform = Wrapper.consolidate_dimension(target)
-      postgres file: transform.to_file, debug: target.debug
+      postgres file: transform.to_file, debug: target.debug, **options
     end
 
-    def relabel_dimension(target)
+    def relabel_dimension(target, options = {})
       transform = Wrapper.relabel_dimension(target)
-      postgres file: transform.to_file, debug: target.debug
+      postgres file: transform.to_file, debug: target.debug, **options
     end
 
-    def load_fact(source_files, source, target, date)
+    def load_fact(source_files, source, target, date, options = {})
       optional_apply_map(source_files, source, target) do |intermediate_files, intermediate|
         transform = Wrapper.load_fact(intermediate_files, intermediate, target, date)
-        postgres file: transform.to_file, debug: (source.debug || target.debug || intermediate.debug)
+        postgres file: transform.to_file, debug: (source.debug || target.debug || intermediate.debug), **options
       end
     end
 
-    def rollup_fact(source, target, date)
+    def rollup_fact(source, target, date, options = {})
       transform = Wrapper.rollup_fact(source, target, date)
-      postgres file: transform.to_file, debug: (source.debug || target.debug)
+      postgres file: transform.to_file, debug: (source.debug || target.debug), **options
     end
 
     private

--- a/lib/masamune/commands/postgres.rb
+++ b/lib/masamune/commands/postgres.rb
@@ -116,7 +116,7 @@ module Masamune::Commands
     end
 
     def failure_message(status)
-      @error
+      @error || 'psql failed without error'
     end
 
     def prompt

--- a/lib/masamune/commands/postgres.rb
+++ b/lib/masamune/commands/postgres.rb
@@ -56,6 +56,7 @@ module Masamune::Commands
         instance_variable_set("@#{name}", value)
       end
       raise ArgumentError, 'Cannot specify both file and exec' if @file && @exec
+      @error = nil
     end
 
     def stdin
@@ -107,6 +108,15 @@ module Masamune::Commands
         @block.call(line) if @block
         console(line) if print?
       end
+    end
+
+    def handle_stderr(line, line_no)
+      @error = line.split(/ERROR:\s*/).last if line =~ /ERROR:/
+      logger.debug(line)
+    end
+
+    def failure_message(status)
+      @error
     end
 
     def prompt

--- a/lib/masamune/commands/shell.rb
+++ b/lib/masamune/commands/shell.rb
@@ -189,7 +189,15 @@ module Masamune::Commands
       if @delegate.respond_to?(:handle_failure)
         @delegate.handle_failure(status)
       end
-      raise "fail_fast: #{command_args.join(' ')}" if fail_fast
+      raise failure_message(status) if fail_fast
+    end
+
+    def failure_message(status)
+      if @delegate.respond_to?(:failure_message)
+        @delegate.failure_message(status)
+      else
+        "fail_fast: #{command_args.join(' ')}"
+      end
     end
 
     private

--- a/lib/masamune/schema/map.rb
+++ b/lib/masamune/schema/map.rb
@@ -124,6 +124,26 @@ module Masamune::Schema
         @line += 1
       end
 
+      def to_s
+        case @io
+        when File, Tempfile
+          @io.path
+        when IO
+          case @io.fileno
+          when 0
+            'STDIN'
+          when 1
+            'STDOUT'
+          when 2
+            'STDERR'
+          else
+            'UNKNOWN'
+          end
+        when StringIO
+          'StringIO'
+        end
+      end
+
       def line
         @line
       end
@@ -225,7 +245,7 @@ module Masamune::Schema
 
     def skip_or_raise(buffer, row, message)
       message = 'failed to process' if message.nil? || message.blank?
-      trace = { message: message, source: source.name, target: target.name, file: buffer.try(:path), line: buffer.try(:line), row: row.try(:to_hash) }
+      trace = { message: message, source: source.name, target: target.name, file: buffer.try(:to_s), line: buffer.try(:line), row: row.try(:to_hash) }
       if fail_fast
         @store.logger.error(message)
         @store.logger.debug(trace)

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -77,7 +77,6 @@ module Masamune
       rescue => e
         instance.logger.error("#{e.message} (#{e.class}) backtrace:")
         e.backtrace.each { |x| instance.logger.error(x) }
-        $stderr.puts e.to_s
         $stderr.puts "For complete debug log see: #{instance.log_file_name.to_s}"
         abort e.message
       end

--- a/lib/masamune/thor.rb
+++ b/lib/masamune/thor.rb
@@ -79,7 +79,7 @@ module Masamune
         e.backtrace.each { |x| instance.logger.error(x) }
         $stderr.puts e.to_s
         $stderr.puts "For complete debug log see: #{instance.log_file_name.to_s}"
-        exit 1
+        abort e.message
       end
     end
 

--- a/spec/masamune/actions/transform_spec.rb
+++ b/spec/masamune/actions/transform_spec.rb
@@ -71,9 +71,14 @@ describe Masamune::Actions::Transform do
 
   let(:instance) { klass.new }
   let(:postgres) { catalog.postgres }
+  let(:options) { { extra_args: true } }
+
+  before do
+    expect(instance).to receive(:postgres).with(hash_including(extra_args: true)).and_call_original
+  end
 
   describe '.load_dimension' do
-    subject { instance.load_dimension(source_file, postgres.user_file, postgres.user_dimension) }
+    subject { instance.load_dimension(source_file, postgres.user_file, postgres.user_dimension, options) }
 
     context 'without :map' do
       before do
@@ -111,7 +116,7 @@ describe Masamune::Actions::Transform do
       mock_command(/\Apsql/, mock_success)
     end
 
-    subject { instance.relabel_dimension(postgres.user_dimension) }
+    subject { instance.relabel_dimension(postgres.user_dimension, options) }
 
     it { is_expected.to be_success }
   end
@@ -121,7 +126,7 @@ describe Masamune::Actions::Transform do
       mock_command(/\Apsql/, mock_success)
     end
 
-    subject { instance.consolidate_dimension(postgres.user_dimension) }
+    subject { instance.consolidate_dimension(postgres.user_dimension, options) }
 
     it { is_expected.to be_success }
   end
@@ -135,7 +140,7 @@ describe Masamune::Actions::Transform do
         mock_command(/\Apsql/, mock_success)
       end
 
-      subject { instance.load_fact(source_file, postgres.visits_hourly_file, postgres.visits_hourly_fact, date) }
+      subject { instance.load_fact(source_file, postgres.visits_hourly_file, postgres.visits_hourly_fact, date, options) }
 
       it { is_expected.to be_success }
     end
@@ -150,7 +155,7 @@ describe Masamune::Actions::Transform do
         mock_command(/\Apsql/, mock_success)
       end
 
-      subject { instance.load_fact(source_file, postgres.visits_hourly_file, postgres.visits_hourly_fact, date) }
+      subject { instance.load_fact(source_file, postgres.visits_hourly_file, postgres.visits_hourly_fact, date, options) }
 
       it { is_expected.to be_success }
     end
@@ -163,7 +168,7 @@ describe Masamune::Actions::Transform do
       mock_command(/\Apsql/, mock_success)
     end
 
-    subject { instance.rollup_fact(postgres.visits_hourly_fact, postgres.visits_daily_fact, date) }
+    subject { instance.rollup_fact(postgres.visits_hourly_fact, postgres.visits_daily_fact, date, options) }
 
     it { is_expected.to be_success }
   end

--- a/spec/masamune/commands/postgres_spec.rb
+++ b/spec/masamune/commands/postgres_spec.rb
@@ -129,5 +129,20 @@ describe Masamune::Commands::Postgres do
     end
   end
 
+  describe '#failure_message' do
+    let(:status_code) { 1 }
+
+    before do
+      expect(instance.logger).to receive(:debug).at_least(3).times
+      instance.handle_stderr('Everything is OK', 0)
+      instance.handle_stderr('psql:/var/tmp/schema.psql ERROR: Something went wrong', 1)
+      instance.handle_stderr('Wha happen', 2)
+    end
+
+    subject { instance.failure_message(status_code) }
+
+    it { is_expected.to eq('Something went wrong') }
+  end
+
   it_should_behave_like Masamune::Commands::PostgresCommon
 end

--- a/spec/masamune/commands/postgres_spec.rb
+++ b/spec/masamune/commands/postgres_spec.rb
@@ -132,16 +132,24 @@ describe Masamune::Commands::Postgres do
   describe '#failure_message' do
     let(:status_code) { 1 }
 
-    before do
-      expect(instance.logger).to receive(:debug).at_least(3).times
-      instance.handle_stderr('Everything is OK', 0)
-      instance.handle_stderr('psql:/var/tmp/schema.psql ERROR: Something went wrong', 1)
-      instance.handle_stderr('Wha happen', 2)
+    context 'when error detected' do
+      before do
+        expect(instance.logger).to receive(:debug).at_least(3).times
+        instance.handle_stderr('Everything is OK', 0)
+        instance.handle_stderr('psql:/var/tmp/schema.psql ERROR: Something went wrong', 1)
+        instance.handle_stderr('Wha happen', 2)
+      end
+
+      subject { instance.failure_message(status_code) }
+
+      it { is_expected.to eq('Something went wrong') }
     end
 
-    subject { instance.failure_message(status_code) }
+    context 'when no error detected' do
+      subject { instance.failure_message(status_code) }
 
-    it { is_expected.to eq('Something went wrong') }
+      it { is_expected.to eq('psql failed without error') }
+    end
   end
 
   it_should_behave_like Masamune::Commands::PostgresCommon

--- a/spec/masamune/commands/shell_spec.rb
+++ b/spec/masamune/commands/shell_spec.rb
@@ -73,6 +73,19 @@ describe Masamune::Commands::Shell do
       it { expect { subject }.to raise_error RuntimeError, "fail_fast: #{command}" }
     end
 
+    context 'with fail_fast and simple command that fails and delegate.failure_message' do
+      let(:command) { %Q{bash -c 'exit 1'} }
+      let(:options) { {fail_fast: true} }
+
+      before do
+        allow(delegate).to receive(:failure_message).and_return('Wha happen')
+        expect(instance.logger).to receive(:debug).with(%q(execute: TZ=UTC bash -c 'exit 1'))
+        expect(instance.logger).to receive(:debug).with(/\Astatus: .* exit 1\z/)
+      end
+
+      it { expect { subject }.to raise_error RuntimeError, 'Wha happen' }
+    end
+
     context 'when command is interrupted' do
       let(:command) { %Q{bash -c "echo 'test'"} }
 

--- a/spec/masamune/schema/map_spec.rb
+++ b/spec/masamune/schema/map_spec.rb
@@ -790,7 +790,7 @@ describe Masamune::Schema::Map do
       end
 
       context ' with Tempfile' do
-        let(:io_delegate) { Tempfile.new }
+        let(:io_delegate) { Tempfile.new('masamune') }
         it { is_expected.to eq(io_delegate.path) }
       end
     end

--- a/spec/masamune/schema/map_spec.rb
+++ b/spec/masamune/schema/map_spec.rb
@@ -746,6 +746,56 @@ describe Masamune::Schema::Map do
     end
   end
 
+  describe Masamune::Schema::Map::Buffer do
+    let(:map) { double }
+    let(:table) { double }
+    let(:instance) { described_class.new(map, table) }
+
+    before do
+      allow(table).to receive(:store).and_return(double)
+      instance.bind(io_delegate)
+    end
+
+    describe '#to_s' do
+      subject { instance.to_s }
+
+      context ' with STDIN' do
+        let(:io_delegate) { STDIN }
+        it { is_expected.to eq('STDIN') }
+      end
+
+      context ' with STDOUT' do
+        let(:io_delegate) { STDOUT }
+        it { is_expected.to eq('STDOUT') }
+      end
+
+      context ' with STDERR' do
+        let(:io_delegate) { STDERR }
+        it { is_expected.to eq('STDERR') }
+      end
+
+      context ' with unknown IO' do
+        let(:io_delegate) { IO.new(IO.sysopen('/dev/null', 'r')) }
+        it { is_expected.to eq('UNKNOWN') }
+      end
+
+      context ' with StringIO' do
+        let(:io_delegate) { StringIO.new }
+        it { is_expected.to eq('StringIO') }
+      end
+
+      context ' with File' do
+        let(:io_delegate) { File.new('/dev/null', 'r') }
+        it { is_expected.to eq(io_delegate.path) }
+      end
+
+      context ' with Tempfile' do
+        let(:io_delegate) { Tempfile.new }
+        it { is_expected.to eq(io_delegate.path) }
+      end
+    end
+  end
+
   describe Masamune::Schema::Map::JSONEncoder do
     let(:io) { StringIO.new }
     let(:store) { double(json_encoding: :raw, format: :csv) }

--- a/spec/masamune/thor_spec.rb
+++ b/spec/masamune/thor_spec.rb
@@ -101,6 +101,7 @@ describe Masamune::Thor do
       it 'exits with status code 0 and prints version' do
         expect { cli_invocation }.to raise_error { |e|
           expect(e).to be_a(SystemExit)
+          expect(e.message).to eq('exit')
           expect(e.status).to eq(0)
         }
         expect(stdout.string).to match(/\Amasamune/)
@@ -206,13 +207,13 @@ describe Masamune::Thor do
       it 'exits with status code 1 and prints error to stderr' do
         expect { cli_invocation }.to raise_error { |e|
           expect(e).to be_a(SystemExit)
+          expect(e.message).to eq('Path :unknown_dir not defined')
           expect(e.status).to eq(1)
         }
         expect(stdout.string).to be_blank
         expect(stderr.string).to match(/Path :unknown_dir not defined/)
       end
     end
-
   end
 
   context 'with command that prints :current_dir' do

--- a/spec/support/masamune/shared_example_group.rb
+++ b/spec/support/masamune/shared_example_group.rb
@@ -41,8 +41,6 @@ module Masamune::SharedExampleGroup
     tmp_stdout, $stdout = $stdout, @stdout
     tmp_stderr, $stderr = $stderr, @stderr
     yield
-  rescue SystemExit => e
-    @status = e.status
   ensure
     $stdout, $stderr = tmp_stdout, tmp_stderr
   end

--- a/spec/support/masamune/task_example_group.rb
+++ b/spec/support/masamune/task_example_group.rb
@@ -33,7 +33,7 @@ module Masamune::TaskExampleGroup
       let(:command) { nil }
       let(:options) { [] }
 
-      subject(:execute_command) do
+      let(:execute_command) do
         n = context_options.fetch(:idempotent, false) ? 2 : 1
         n = 1 if ENV['MASAMUNE_FASTER_SPEC']
         capture(!default_options.include?('--debug')) do
@@ -44,6 +44,10 @@ module Masamune::TaskExampleGroup
           end
         end
       end
+
+      before do
+        expect { execute_command }.to_not raise_error
+      end unless context_options[:execute_command] == false
     end
   end
 

--- a/spec/support/masamune/task_example_group.rb
+++ b/spec/support/masamune/task_example_group.rb
@@ -32,7 +32,7 @@ module Masamune::TaskExampleGroup
       let(:command) { nil }
       let(:options) { [] }
 
-      let(:execute_command) do
+      subject(:execute_command) do
         n = context_options.fetch(:idempotent, false) ? 2 : 1
         n = 1 if ENV['MASAMUNE_FASTER_SPEC']
         capture(!default_options.include?('--debug')) do
@@ -43,10 +43,6 @@ module Masamune::TaskExampleGroup
           end
         end
       end
-
-      before do
-        expect { execute_command }.to_not raise_error
-      end unless context_options[:execute_command] == false
     end
   end
 

--- a/spec/support/masamune/task_example_group.rb
+++ b/spec/support/masamune/task_example_group.rb
@@ -28,7 +28,6 @@ module Masamune::TaskExampleGroup
 
       let(:stdout) { @stdout }
       let(:stderr) { @stderr }
-      let(:status) { @status }
 
       let(:command) { nil }
       let(:options) { [] }


### PR DESCRIPTION
- Add `fail_fast` option to `map` causing `map` to fail instead of skip invalid records
- Return useful error messages from `postgres`
- Abort with error message instead of printing to `STDERR`