### PR TITLE
More safe row

### DIFF
--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -288,7 +288,7 @@ module Masamune::Schema
           {}
         end
       when :string
-        value.to_s
+        value.blank? ? nil : value.to_s
       else
         value
       end

--- a/lib/masamune/schema/map.rb
+++ b/lib/masamune/schema/map.rb
@@ -157,10 +157,10 @@ module Masamune::Schema
       end
 
       def safe_row(data)
-        row = Masamune::Schema::Row.new(parent: @table, values: data.to_hash, strict: false)
+        row = Masamune::Schema::Row.new(parent: @table, values: data.to_hash, strict: @map.fail_fast)
         row.to_hash
-      rescue
-        @map.skip_or_raise(self, data, 'failed to parse')
+      rescue => e
+        @map.skip_or_raise(self, data, e.message || 'failed to parse')
       end
 
       def append?(elem)

--- a/spec/masamune/schema/column_spec.rb
+++ b/spec/masamune/schema/column_spec.rb
@@ -364,6 +364,30 @@ describe Masamune::Schema::Column do
       end
     end
 
+    context 'with type :string' do
+      let(:column) { described_class.new(id: 'string', type: :string) }
+
+      context 'when nil' do
+        let(:value) { nil }
+        it { is_expected.to be(nil) }
+      end
+
+      context 'when blank' do
+        let(:value) { '' }
+        it { is_expected.to be(nil) }
+      end
+
+      context 'when String' do
+        let(:value) { 'value' }
+        it { is_expected.to eq('value') }
+      end
+
+      context 'when Integer' do
+        let(:value) { '1' }
+        it { is_expected.to eq('1') }
+      end
+    end
+
     context 'with type :timestamp' do
       let(:column) { described_class.new(id: 'timestamp', type: :timestamp) }
 

--- a/spec/masamune/schema/dimension_spec.rb
+++ b/spec/masamune/schema/dimension_spec.rb
@@ -80,7 +80,7 @@ describe Masamune::Schema::Dimension do
         ]
     end
 
-    it { expect { dimension }.to raise_error ArgumentError, /contains undefined columns/ }
+    it { expect { dimension }.to raise_error /contains undefined columns/ }
   end
 
   context 'for type :four' do

--- a/spec/masamune/schema/map_spec.rb
+++ b/spec/masamune/schema/map_spec.rb
@@ -253,9 +253,9 @@ describe Masamune::Schema::Map do
             "deleted_at"  => nil
           }
         ).ordered
-        expect(environment.logger).to receive(:warn).with(/failed to parse/).ordered
+        expect(environment.logger).to receive(:warn).with("Could not coerce 'INVALID_JSON' into :json for column 'preferences'").ordered
         expect(environment.logger).to receive(:debug).with(
-          :message => "failed to parse",
+          :message => "Could not coerce 'INVALID_JSON' into :json for column 'preferences'",
           :source  => "input_stage",
           :target  => "user_dimension_ledger",
           :file    => input.path,

--- a/spec/masamune/schema/map_spec.rb
+++ b/spec/masamune/schema/map_spec.rb
@@ -176,22 +176,20 @@ describe Masamune::Schema::Map do
       end
 
       before do
-        expect(environment.logger).to receive(:warn).with(/missing required columns 'user_id'/).ordered
+        expect(environment.logger).to receive(:warn).with(/missing required columns 'id'/).ordered
         expect(environment.logger).to receive(:debug).with(
-          :message => %q(missing required columns 'user_id'),
+          :message => %q(missing required columns 'id'),
           :source  => 'user_stage',
           :target  => 'user_dimension_ledger',
-          :file    => output.path,
+          :file    => input.path,
           :line    => 3,
           :row     => {
-            'tenant_id'                  => 50,
-            'user_id'                    => nil,
-            'user_account_state.name'    => 'active',
-            'hr_user_account_state.name' => 'active',
-            'admin'                      => false,
-            'preferences'                => {},
-            'source'                     => 'users_file',
-            'cluster_id'                 => 100
+            'id'          => nil,
+            'tenant_id'   => '50',
+            'junk_id'     => 'X',
+            'deleted_at'  => nil,
+            'admin'       => '0',
+            'preferences' => nil
           }
         ).ordered
       end

--- a/spec/masamune/schema/table_spec.rb
+++ b/spec/masamune/schema/table_spec.rb
@@ -135,7 +135,7 @@ describe Masamune::Schema::Table do
         ]
     end
 
-    it { expect { table }.to raise_error ArgumentError, /contains undefined columns/ }
+    it { expect { table }.to raise_error /contains undefined columns/ }
   end
 
   context 'with partial values' do


### PR DESCRIPTION
- Cast blank strings as `nil`
- Move missing required columns check into `Row`
- Reuse `safe_row` helper for both map input and output. This allows the map to `fail_fast` while reading an input file. For example if a file has a column that is not declared as `null`, but the value is `NULL` the map will `fail_fast`
- Encapsulate `errors` collection in `Row` - report errors in map with `skip_or_raise`