### PR TITLE
Fix `Tempfile.new`

### DIFF
--- a/lib/masamune/actions/transform.rb
+++ b/lib/masamune/actions/transform.rb
@@ -86,7 +86,7 @@ module Masamune::Actions
     end
 
     def apply_map(map, source_files, source, target)
-      Tempfile.open('masamune') do |output|
+      Tempfile.open('masamune_transform') do |output|
         begin
           FileUtils.chmod(FILE_MODE, output.path)
           result = map.apply(source_files, output)

--- a/lib/masamune/commands/hive.rb
+++ b/lib/masamune/commands/hive.rb
@@ -97,7 +97,7 @@ module Masamune::Commands
       end
 
       if @output
-        @buffer = Tempfile.new('masamune')
+        @buffer = Tempfile.create('masamune')
       end
     end
 
@@ -172,9 +172,9 @@ module Masamune::Commands
     end
 
     def exec_file
-      Tempfile.new('masamune').tap do |tmp|
+      @exec_file ||= Tempfile.create('masamune').tap do |tmp|
         tmp.write(@exec)
-        tmp.flush
+        tmp.close
       end.path
     end
 

--- a/lib/masamune/commands/hive.rb
+++ b/lib/masamune/commands/hive.rb
@@ -114,6 +114,8 @@ module Masamune::Commands
       return unless @output
 
       filesystem.move_file_to_file(@buffer.path, @output)
+    ensure
+      File.delete(@buffer.path) if @buffer && @buffer.path && File.exists?(@buffer.path)
     end
 
     def handle_stdout(line, line_no)

--- a/lib/masamune/commands/hive.rb
+++ b/lib/masamune/commands/hive.rb
@@ -97,7 +97,7 @@ module Masamune::Commands
       end
 
       if @output
-        @buffer = Tempfile.create('masamune')
+        @buffer = Tempfile.create('masamune_hive_output')
       end
     end
 
@@ -172,7 +172,7 @@ module Masamune::Commands
     end
 
     def exec_file
-      @exec_file ||= Tempfile.create('masamune').tap do |tmp|
+      @exec_file ||= Tempfile.create('masamune_hive_input').tap do |tmp|
         tmp.write(@exec)
         tmp.close
       end.path

--- a/lib/masamune/commands/postgres.rb
+++ b/lib/masamune/commands/postgres.rb
@@ -146,7 +146,7 @@ module Masamune::Commands
     end
 
     def exec_file
-      @exec_file ||= Tempfile.create('masamune').tap do |tmp|
+      @exec_file ||= Tempfile.create('masamune_psql_input').tap do |tmp|
         tmp.write(@exec)
         tmp.close
       end.path

--- a/lib/masamune/commands/postgres.rb
+++ b/lib/masamune/commands/postgres.rb
@@ -146,9 +146,9 @@ module Masamune::Commands
     end
 
     def exec_file
-      Tempfile.new('masamune').tap do |tmp|
+      @exec_file ||= Tempfile.create('masamune').tap do |tmp|
         tmp.write(@exec)
-        tmp.flush
+        tmp.close
       end.path
     end
 

--- a/lib/masamune/filesystem.rb
+++ b/lib/masamune/filesystem.rb
@@ -147,7 +147,7 @@ module Masamune
         when :hdfs
           hadoop_fs('-touchz', *file_set)
         when :s3
-          empty = Tempfile.new('masamune')
+          empty = Tempfile.new('masamune_empty')
           file_set.each do |file|
             s3cmd('put', empty.path, s3b(file, dir: false))
           end

--- a/lib/masamune/template.rb
+++ b/lib/masamune/template.rb
@@ -52,7 +52,7 @@ module Masamune
 
     class << self
       def render_to_file(template, parameters = {})
-        Tempfile.new('masamune').tap do |file|
+        Tempfile.create('masamune').tap do |file|
           file.write(render_to_string(template, parameters))
           file.close
         end.path

--- a/lib/masamune/template.rb
+++ b/lib/masamune/template.rb
@@ -52,7 +52,7 @@ module Masamune
 
     class << self
       def render_to_file(template, parameters = {})
-        Tempfile.create('masamune').tap do |file|
+        Tempfile.create('masamune_template').tap do |file|
           file.write(render_to_string(template, parameters))
           file.close
         end.path

--- a/lib/masamune/transform/operator.rb
+++ b/lib/masamune/transform/operator.rb
@@ -42,7 +42,7 @@ module Masamune::Transform
     end
 
     def to_file
-      Tempfile.create('masamune').tap do |file|
+      Tempfile.create('masamune_operator').tap do |file|
         file.write(to_s)
         file.close
       end.path

--- a/lib/masamune/transform/operator.rb
+++ b/lib/masamune/transform/operator.rb
@@ -42,7 +42,7 @@ module Masamune::Transform
     end
 
     def to_file
-      Tempfile.new('masamune').tap do |file|
+      Tempfile.create('masamune').tap do |file|
         file.write(to_s)
         file.close
       end.path


### PR DESCRIPTION
I noticed a stack trace where a file generated by `Tempfile.new` was not found ("No such file or directory"). If the file generated by `Tempfile.new` goes out of scope it is possible for [it to be garbage collected and unlinked](http://ruby-doc.org/stdlib-2.3.0/libdoc/tempfile/rdoc/Tempfile.html):
> When a Tempfile object is garbage collected, or when the Ruby interpreter exits, its associated temporary file is automatically deleted. 

Fixed by calling [`Tempfile.create`](http://ruby-doc.org/stdlib-2.3.0/libdoc/tempfile/rdoc/Tempfile.html#method-c-create) which creates a regular file that requires manual garbage collection:
> Creates a temporary file as usual File object (not Tempfile). It doesn’t use finalizer and delegation.

This has the added benefit of persisting the tempfile to aid in debugging. The only downside it's possible to exhaust tempfile names and/or disk space. This risk is typically mitigated by running `tmpreaper` as a cronjob. I also took the liberty of generating the tempfile name based on context to reduce risk of tempfile name exhaustion.

Stack trace:
```
D, [2016-03-23T19:22:25.828472 #41990] DEBUG -- : execute: PGOPTIONS=--client-min-messages=warning PGPASSFILE=/etc/etl/shared/pgpass TZ=UTC psql --host=localhost --dbname=medi_a --username=eventrobot --no
-password --set=ON_ERROR_STOP=1 --file=/opt/var/tmp/masamune20160323-41990-r72wm2 --pset=tuples_only
D, [2016-03-23T19:22:25.887149 #41990] DEBUG -- : /opt/var/tmp/masamune20160323-41990-r72wm2: No such file or directory
D, [2016-03-23T19:22:25.888596 #41990] DEBUG -- : status: pid 42160 exit 1
E, [2016-03-23T19:22:25.889027 #41990] ERROR -- : exited with code: 1
D, [2016-03-23T19:22:35.889417 #41990] DEBUG -- : max retries (0) attempted, bailing
D, [2016-03-23T19:22:35.890084 #41990] DEBUG -- : releasing lock 'data_flow_after_initialize_41990'
E, [2016-03-23T19:22:35.890306 #41990] ERROR -- : psql failed without error (RuntimeError) backtrace:
E, [2016-03-23T19:22:35.890349 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/commands/shell.rb:193:in `handle_failure'
E, [2016-03-23T19:22:35.890379 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/commands/shell.rb:113:in `execute'
E, [2016-03-23T19:22:35.890405 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/actions/postgres.rb:41:in `postgres'
E, [2016-03-23T19:22:35.890431 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/helpers/postgres.rb:76:in `update_table_last_modified_at'
E, [2016-03-23T19:22:35.890457 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/helpers/postgres.rb:54:in `table_last_modified_at'
E, [2016-03-23T19:22:35.890482 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/elem.rb:65:in `last_modified_at'
E, [2016-03-23T19:22:35.890508 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:172:in `target_stale?'
E, [2016-03-23T19:22:35.890533 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:76:in `block (2 levels) in stale'
E, [2016-03-23T19:22:35.890558 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:283:in `each_key'
E, [2016-03-23T19:22:35.890582 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:283:in `each'
E, [2016-03-23T19:22:35.890606 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:76:in `any?'
E, [2016-03-23T19:22:35.890632 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:76:in `block in stale'
E, [2016-03-23T19:22:35.890657 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:283:in `each_key'
E, [2016-03-23T19:22:35.890698 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:283:in `each'
E, [2016-03-23T19:22:35.890737 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:75:in `stale'
E, [2016-03-23T19:22:35.890764 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:99:in `actionable'
E, [2016-03-23T19:22:35.890789 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:94:in `each'
E, [2016-03-23T19:22:35.890814 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:94:in `each_entry'
E, [2016-03-23T19:22:35.890838 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:94:in `do_with_enum'
E, [2016-03-23T19:22:35.890862 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:375:in `merge'
E, [2016-03-23T19:22:35.890886 #41990] ERROR -- : /usr/lib/ruby/2.2.0/set.rb:88:in `initialize'
E, [2016-03-23T19:22:35.890910 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:32:in `initialize'
E, [2016-03-23T19:22:35.890935 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:91:in `new'
E, [2016-03-23T19:22:35.891121 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/set.rb:91:in `actionable'
E, [2016-03-23T19:22:35.891150 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/data_plan/engine.rb:136:in `execute'
E, [2016-03-23T19:22:35.891198 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/actions/data_flow.rb:73:in `execute'
E, [2016-03-23T19:22:35.891230 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/actions/data_flow.rb:95:in `block (3 levels) in <module:DataFlow>'
E, [2016-03-23T19:22:35.891256 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/environment.rb:78:in `block in with_process_lock'
E, [2016-03-23T19:22:35.891282 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/environment.rb:65:in `with_exclusive_lock'
E, [2016-03-23T19:22:35.891318 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/environment.rb:77:in `with_process_lock'
E, [2016-03-23T19:22:35.891345 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/actions/data_flow.rb:94:in `block (2 levels) in <module:DataFlow>'
E, [2016-03-23T19:22:35.891370 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/after_initialize_callbacks.rb:45:in `call'
E, [2016-03-23T19:22:35.891395 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/after_initialize_callbacks.rb:45:in `block (2 levels) in after_initialize_invoke'
E, [2016-03-23T19:22:35.891420 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/after_initialize_callbacks.rb:45:in `each'
E, [2016-03-23T19:22:35.891445 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/after_initialize_callbacks.rb:45:in `block in after_initialize_invoke'
E, [2016-03-23T19:22:35.891469 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/after_initialize_callbacks.rb:45:in `each'
E, [2016-03-23T19:22:35.891494 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/after_initialize_callbacks.rb:45:in `after_initialize_invoke'
E, [2016-03-23T19:22:35.891518 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/after_initialize_callbacks.rb:50:in `after_initialize_invoke'
E, [2016-03-23T19:22:35.891575 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/thor.rb:154:in `initialize'
E, [2016-03-23T19:22:35.891604 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:355:in `new'
E, [2016-03-23T19:22:35.891628 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:355:in `dispatch'
E, [2016-03-23T19:22:35.891652 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
E, [2016-03-23T19:22:35.891676 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.17.7/lib/masamune/thor.rb:70:in `start'
E, [2016-03-23T19:22:35.891701 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/runner.rb:36:in `method_missing'
E, [2016-03-23T19:22:35.891724 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:29:in `run'
E, [2016-03-23T19:22:35.891748 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:126:in `run'
E, [2016-03-23T19:22:35.891773 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
E, [2016-03-23T19:22:35.891797 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
E, [2016-03-23T19:22:35.891821 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
E, [2016-03-23T19:22:35.891846 #41990] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/bin/thor:6:in `<top (required)>'
```