### PR TITLE
Ensure execute is called with RetryWithBackoff

### DIFF
--- a/lib/masamune/actions/execute.rb
+++ b/lib/masamune/actions/execute.rb
@@ -56,7 +56,9 @@ module Masamune::Actions
         end
       end if block_given?
 
-      command = Masamune::Commands::Shell.new(klass.new(self), {fail_fast: false}.merge(opts))
+      command = klass.new(self)
+      command = Masamune::Commands::RetryWithBackoff.new(command, opts)
+      command = Masamune::Commands::Shell.new(command, {fail_fast: false}.merge(opts))
       opts.fetch(:interactive, false) ? command.replace(opts) : command.execute
     end
   end

--- a/spec/masamune/actions/execute_spec.rb
+++ b/spec/masamune/actions/execute_spec.rb
@@ -39,6 +39,10 @@ describe Masamune::Actions::Execute do
   let(:instance) { klass.new }
 
   describe '.execute' do
+    before do
+      expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, anything).once.and_call_original
+    end
+
     context 'with a simple command' do
       let(:command) { %w(echo ping) }
       let(:options) { {fail_fast: true} }


### PR DESCRIPTION
Occasionally the `execute` action is used in a `before_execute` or `after_execute` of another Command, for example to [generate the ssh args from `aws emr`](https://github.com/socialcast/masamune/blob/8a9c1659e0efda98b9078cce54ad4975acb3cb0d/lib/masamune/commands/aws_emr.rb#L80). Ensure that this command also retries with backoff