### PR TITLE
Skip potential last_modified_at records if they are blank

### DIFF
--- a/lib/masamune/helpers/postgres.rb
+++ b/lib/masamune/helpers/postgres.rb
@@ -74,7 +74,8 @@ module Masamune::Helpers
     def update_table_last_modified_at(table, column)
       return if @cache[table].present?
       postgres(exec: "SELECT MAX(#{column}) FROM #{table};", tuple_output: true, retries: 0) do |line|
-        @cache[table] = parse_date_time(line.strip)
+        last_modified_at = line.strip
+        @cache[table] = parse_date_time(last_modified_at) unless last_modified_at.blank?
       end
     end
 

--- a/spec/masamune/helpers/postgres_spec.rb
+++ b/spec/masamune/helpers/postgres_spec.rb
@@ -74,7 +74,7 @@ describe Masamune::Helpers::Postgres do
     context 'with last_modified_at option' do
       before do
         expect(instance).to receive(:table_exists?).and_return(true)
-        expect(instance).to receive(:postgres).with(hash_including(exec: 'SELECT MAX(last_modified_at) FROM foo;', tuple_output: true, retries: 0)).and_yield(output)
+        expect(instance).to receive(:postgres).with(hash_including(exec: 'SELECT MAX(last_modified_at) FROM foo;', tuple_output: true, retries: 0)).and_yield(output).and_yield('')
       end
 
       let(:options) { { last_modified_at: 'last_modified_at' } }


### PR DESCRIPTION
After rubocop modifications, the behavior of parsing table `last_modified_at` changed. Updated the spec to produce actual output from `postgres(exec: ...)` call and fixed the parsing logic.

Debug log:
```
etl> targets.stale
postgres exec 'SELECT MAX(last_modified_at) FROM visitation_daily_fact_y2016m04;'
postgres exec 'SELECT MAX(last_modified_at) FROM visitation_daily_fact_y2016m05;'
postgres exec 'SELECT MAX(last_modified_at) FROM visitation_daily_fact_y2016m06;'
=> #<Masamune::DataPlan::Set: {}>
etl> targets.sources.existing.map(&:last_modified_at)
postgres exec 'SELECT MAX(last_modified_at) FROM visitation_hourly_fact_y2016m04;'
postgres exec 'SELECT MAX(last_modified_at) FROM visitation_hourly_fact_y2016m05;'
postgres exec 'SELECT MAX(last_modified_at) FROM visitation_hourly_fact_y2016m06;'
=> [0000-01-01 00:00:00 +0000, 0000-01-01 00:00:00 +0000, 0000-01-01 00:00:00 +0000]
etl> Masamune::DataPlan::Elem::MISSING_MODIFIED_AT
=> 0000-01-01 00:00:00 +0000

etl> postgres(exec: "SELECT MAX(last_modified_at) FROM visitation_daily_fact_y2016m06;", tuple_output: true, retries: 0) do |line|
 p line
end
postgres exec 'SELECT MAX(last_modified_at) FROM visitation_daily_fact_y2016m06;'
" 2016-06-02 05:59:36.154132"
""
```