### PR TITLE
Remove extraneous UPDATE and GROUP BY

### DIFF
--- a/lib/masamune/transform/postgres/relabel_dimension.psql.erb
+++ b/lib/masamune/transform/postgres/relabel_dimension.psql.erb
@@ -24,9 +24,6 @@ SELECT pg_advisory_lock(<%= target.lock_id %>);
 
 BEGIN;
 
-<%-# Relabel version column -%>
-UPDATE <%= target.name %> SET version = NULL;
-
 UPDATE
   <%= target.name %>
 SET
@@ -42,15 +39,10 @@ FROM
       rank() OVER (PARTITION BY <%= target.window.join(', ') %> ORDER BY start_at) AS version
     FROM
       <%= target.name %>
-    GROUP BY
-      <%= target.window(:id, :start_at).join(', ') %>
    ) AS tmp
 WHERE
   <%= target.name %>.id = tmp.id
 ;
-
-<%-# Relabel end_at column -%>
-UPDATE <%= target.name %> SET end_at = NULL;
 
 UPDATE
   <%= target.name %>
@@ -67,8 +59,6 @@ FROM
       LEAD(start_at, 1) OVER (PARTITION BY <%= target.window.join(', ') %> ORDER BY start_at) AS end_at
     FROM
       <%= target.name %>
-    GROUP BY
-      <%= target.window(:id, :start_at).join(', ') %>
    ) AS tmp
 WHERE
   <%= target.name %>.id = tmp.id

--- a/spec/masamune/transform/relabel_dimension_spec.rb
+++ b/spec/masamune/transform/relabel_dimension_spec.rb
@@ -50,8 +50,6 @@ describe Masamune::Transform::RelabelDimension do
 
         BEGIN;
 
-        UPDATE user_dimension SET version = NULL;
-
         UPDATE
           user_dimension
         SET
@@ -66,14 +64,10 @@ describe Masamune::Transform::RelabelDimension do
               rank() OVER (PARTITION BY tenant_id, user_id ORDER BY start_at) AS version
             FROM
               user_dimension
-            GROUP BY
-              id, tenant_id, user_id, start_at
            ) AS tmp
         WHERE
           user_dimension.id = tmp.id
         ;
-
-        UPDATE user_dimension SET end_at = NULL;
 
         UPDATE
           user_dimension
@@ -89,8 +83,6 @@ describe Masamune::Transform::RelabelDimension do
               LEAD(start_at, 1) OVER (PARTITION BY tenant_id, user_id ORDER BY start_at) AS end_at
             FROM
               user_dimension
-            GROUP BY
-              id, tenant_id, user_id, start_at
            ) AS tmp
         WHERE
           user_dimension.id = tmp.id


### PR DESCRIPTION
Previous query plan:
```
                                                                                    QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Update on user_dimension  (cost=569386.21..822854.67 rows=2102641 width=342)
   ->  Hash Join  (cost=569386.21..822854.67 rows=2102641 width=342)
         Hash Cond: (tmp.id = user_dimension.id)
         ->  Subquery Scan on tmp  (cost=366600.78..440193.22 rows=2102641 width=68)
               ->  WindowAgg  (cost=366600.78..419166.81 rows=2102641 width=24)
                     ->  Sort  (cost=366600.78..371857.39 rows=2102641 width=24)
                           Sort Key: user_dimension_1.cluster_type_id, user_dimension_1.tenant_id, user_dimension_1.user_id, user_dimension_1.start_at
                           ->  HashAggregate  (cost=124757.42..145783.83 rows=2102641 width=24)
                                 Group Key: user_dimension_1.id, user_dimension_1.cluster_type_id, user_dimension_1.tenant_id, user_dimension_1.user_id, user_dimension_1.start_at
                                 ->  Seq Scan on user_dimension user_dimension_1  (cost=0.00..98474.41 rows=2102641 width=24)
         ->  Hash  (cost=98474.41..98474.41 rows=2102641 width=278)
               ->  Seq Scan on user_dimension  (cost=0.00..98474.41 rows=2102641 width=278)
(12 rows)
```

Latest query plan:
```
                                                                         QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------
 Update on user_dimension  (cost=363979.08..515019.51 rows=2102641 width=342)
   ->  Hash Join  (cost=363979.08..515019.51 rows=2102641 width=342)
         Hash Cond: (user_dimension.id = tmp.id)
         ->  Seq Scan on user_dimension  (cost=0.00..98474.41 rows=2102641 width=278)
         ->  Hash  (cost=337696.06..337696.06 rows=2102641 width=68)
               ->  Subquery Scan on tmp  (cost=0.43..337696.06 rows=2102641 width=68)
                     ->  WindowAgg  (cost=0.43..316669.65 rows=2102641 width=24)
                           ->  Index Scan using user_dimension_3fcebfa_key on user_dimension user_dimension_1  (cost=0.43..269360.23 rows=2102641 width=24)
(8 rows)
```
