### PR TITLE
 Clean up TaskExampleGroup

### DIFF
--- a/spec/masamune/tasks/aws_emr_thor_spec.rb
+++ b/spec/masamune/tasks/aws_emr_thor_spec.rb
@@ -45,7 +45,7 @@ describe Masamune::Tasks::AwsEmrThor do
         let(:options) { ['--cluster-id=j-XYZ'] }
         it do
           expect_any_instance_of(described_class).to receive(:aws_emr).with(hash_including(action: action, cluster_id: 'j-XYZ')).once.and_return(mock_success)
-          cli_invocation
+          execute_command
         end
       end
     end
@@ -57,7 +57,7 @@ describe Masamune::Tasks::AwsEmrThor do
 
       it do
         expect_any_instance_of(described_class).to receive(:aws_emr).with(hash_including(action: action)).once.and_return(mock_success)
-        cli_invocation
+        execute_command
       end
 
       context 'with --help' do

--- a/spec/masamune/tasks/hive_thor_spec.rb
+++ b/spec/masamune/tasks/hive_thor_spec.rb
@@ -36,7 +36,7 @@ describe Masamune::Tasks::HiveThor do
 
     it do
       expect_any_instance_of(described_class).to receive(:hive).with(hash_including(retries: 0)).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -46,7 +46,7 @@ describe Masamune::Tasks::HiveThor do
       expect_any_instance_of(described_class).to receive(:hive).with(exec: 'CREATE DATABASE IF NOT EXISTS masamune;', database: nil).and_return(mock_success)
       expect_any_instance_of(described_class).to receive(:hive).with(file: instance_of(String)).and_return(mock_success)
       expect_any_instance_of(described_class).to receive(:hive).with(hash_including(file: File.expand_path('zombo.hql'))).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -54,7 +54,7 @@ describe Masamune::Tasks::HiveThor do
     let(:options) { ['--file=zombo.hql'] }
     it do
       expect_any_instance_of(described_class).to receive(:hive).with(hash_including(file: File.expand_path('zombo.hql'))).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -62,7 +62,7 @@ describe Masamune::Tasks::HiveThor do
     let(:options) { ['--output=report.txt'] }
     it do
       expect_any_instance_of(described_class).to receive(:hive).with(hash_including(output: File.expand_path('report.txt'))).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -70,7 +70,7 @@ describe Masamune::Tasks::HiveThor do
     let(:options) { ['--variables=YEAR:2015', 'MONTH:1'] }
     it do
       expect_any_instance_of(described_class).to receive(:hive).with(hash_including(variables: { 'YEAR' => '2015', 'MONTH' => '1' })).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -78,7 +78,7 @@ describe Masamune::Tasks::HiveThor do
     let(:options) { ['-X', 'YEAR:2015', 'MONTH:1'] }
     it do
       expect_any_instance_of(described_class).to receive(:hive).with(hash_including(variables: { 'YEAR' => '2015', 'MONTH' => '1' })).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -86,7 +86,7 @@ describe Masamune::Tasks::HiveThor do
     let(:options) { ['--retry'] }
     it do
       expect_any_instance_of(described_class).to receive(:hive).with(hash_excluding(retries: 0)).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 end

--- a/spec/masamune/tasks/postgres_thor_spec.rb
+++ b/spec/masamune/tasks/postgres_thor_spec.rb
@@ -33,7 +33,7 @@ describe Masamune::Tasks::PostgresThor do
 
     it do
       expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(retries: 0)).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -42,7 +42,7 @@ describe Masamune::Tasks::PostgresThor do
     it do
       expect_any_instance_of(described_class).to receive(:postgres).with(file: instance_of(String), retries: 0).once.and_return(mock_success)
       expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(file: 'zombo.hql')).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -50,7 +50,7 @@ describe Masamune::Tasks::PostgresThor do
     let(:options) { ['--file=zombo.hql'] }
     it do
       expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(file: 'zombo.hql')).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 
@@ -58,7 +58,7 @@ describe Masamune::Tasks::PostgresThor do
     let(:options) { ['--retry'] }
     it do
       expect_any_instance_of(described_class).to receive(:postgres).with(hash_excluding(retries: 0)).once.and_return(mock_success)
-      cli_invocation
+      execute_command
     end
   end
 end

--- a/spec/masamune/tasks/shell_thor_spec.rb
+++ b/spec/masamune/tasks/shell_thor_spec.rb
@@ -31,7 +31,7 @@ describe Masamune::Tasks::ShellThor do
   context 'with no arguments' do
     it do
       expect(Pry).to receive(:start)
-      cli_invocation
+      execute_command
     end
   end
 

--- a/spec/masamune/thor_spec.rb
+++ b/spec/masamune/thor_spec.rb
@@ -41,12 +41,6 @@ describe Masamune::Thor do
         # NOP
       end
 
-      desc 'current_dir', 'current_dir'
-      skip
-      def current_dir_task
-        console(fs.path(:current_dir))
-      end
-
       desc 'unknown', 'unknown'
       target path: fs.path(:unknown_dir, 'target/%Y-%m-%d')
       source path: fs.path(:unknown_dir, 'source/%Y%m%d*.log')
@@ -70,7 +64,7 @@ describe Masamune::Thor do
       end
 
       it 'continues execution' do
-        expect { cli_invocation }.to_not raise_error
+        expect { execute_command }.to_not raise_error
       end
     end
 
@@ -99,7 +93,7 @@ describe Masamune::Thor do
       let(:command) { 'command' }
       let(:options) { ['--version'] }
       it 'exits with status code 0 and prints version' do
-        expect { cli_invocation }.to raise_error { |e|
+        expect { execute_command }.to raise_error { |e|
           expect(e).to be_a(SystemExit)
           expect(e.message).to eq('exit')
           expect(e.status).to eq(0)
@@ -188,7 +182,7 @@ describe Masamune::Thor do
         expect_any_instance_of(Logger).to receive(:error).with(/random exception/)
         allow(thor_class).to receive(:dispatch).and_raise('random exception')
       end
-      it { expect { cli_invocation }.to raise_error(/random exception/) }
+      it { expect { execute_command }.to raise_error(/random exception/) }
     end
 
     context 'with command that raises exception after initialization' do
@@ -198,14 +192,14 @@ describe Masamune::Thor do
         expect_any_instance_of(Logger).to receive(:error).with(/random exception/)
         allow(thor_class).to receive(:after_initialize_invoke).and_raise('random exception')
       end
-      it { expect { cli_invocation }.to raise_error(/random exception/) }
+      it { expect { execute_command }.to raise_error(/random exception/) }
     end
 
     context 'with command that raises exception during execution' do
       let(:command) { 'unknown' }
       let(:options) { ['--start', '2013-01-01'] }
       it 'exits with status code 1 and prints error to stderr' do
-        expect { cli_invocation }.to raise_error { |e|
+        expect { execute_command }.to raise_error { |e|
           expect(e).to be_a(SystemExit)
           expect(e.message).to eq('Path :unknown_dir not defined')
           expect(e.status).to eq(1)
@@ -222,15 +216,16 @@ describe Masamune::Thor do
         include Masamune::Thor
 
         desc 'current_dir', 'current_dir'
-        def current_dir
+        def current_dir_task
           console(fs.path(:current_dir))
         end
       end
     end
 
     let(:command) { 'current_dir' }
+    let(:options) { ['--no-quiet'] }
     it 'prints :current_dir' do
-      cli_invocation
+      execute_command
       expect(stdout.string).to eq(File.dirname(__FILE__) + "\n")
       expect(stderr.string).to be_blank
     end

--- a/spec/support/masamune/example_group.rb
+++ b/spec/support/masamune/example_group.rb
@@ -29,10 +29,9 @@ module Masamune::ExampleGroup
   include Masamune::HasEnvironment
   extend self # rubocop:disable Style/ModuleFunction
 
-  included do |base|
-    base.before(:all) do
+  included do
+    before(:all) do
       filesystem.environment = self.environment = Masamune::ExampleGroup.environment
-      Thor.send(:include, Masamune::ThorMute)
     end
   end
 end

--- a/spec/support/masamune/example_group.rb
+++ b/spec/support/masamune/example_group.rb
@@ -24,10 +24,12 @@ require 'masamune/has_environment'
 
 # Separate environment for test harness itself
 module Masamune::ExampleGroup
+  extend ActiveSupport::Concern
+
   include Masamune::HasEnvironment
   extend self # rubocop:disable Style/ModuleFunction
 
-  def self.included(base)
+  included do |base|
     base.before(:all) do
       filesystem.environment = self.environment = Masamune::ExampleGroup.environment
       Thor.send(:include, Masamune::ThorMute)

--- a/spec/support/masamune/job_example_group.rb
+++ b/spec/support/masamune/job_example_group.rb
@@ -20,39 +20,38 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
+require_relative 'shared_example_group'
+
 module Masamune::JobExampleGroup
-  module JobFixtureContext
-    shared_context 'job_fixture' do |context_options = {}|
-      fixture_file = example_fixture_file(context_options.slice(:fixture, :file, :path))
-      let(:fixture) { example_fixture(file: fixture_file) }
+  extend ActiveSupport::Concern
 
-      before :all do
-        load_example_config!
-        clean_example_run!
-      end
+  include Masamune::ExampleGroup
+  include Masamune::SharedExampleGroup
+  include Masamune::Actions::Filesystem
+  include Masamune::Actions::Hive
+  include Masamune::Actions::Postgres
 
-      before do
-        setup_example_input!(fixture)
-      end
+  shared_context 'job_fixture' do |context_options = {}|
+    fixture_file = example_fixture_file(context_options.slice(:fixture, :file, :path))
+    let(:fixture) { example_fixture(file: fixture_file) }
 
-      it "should match #{fixture_file}" do
-        aggregate_failures 'generates expected output' do
-          gather_example_output(fixture) do |actual_data, expect_file, expect_data|
-            expect(File.exist?(expect_file)).to eq(true)
-            expect(actual_data).to eq(expect_data)
-          end
+    before :all do
+      load_example_config!
+      clean_example_run!
+    end
+
+    before do
+      setup_example_input!(fixture)
+    end
+
+    it "should match #{fixture_file}" do
+      aggregate_failures 'generates expected output' do
+        gather_example_output(fixture) do |actual_data, expect_file, expect_data|
+          expect(File.exist?(expect_file)).to eq(true)
+          expect(actual_data).to eq(expect_data)
         end
       end
     end
-  end
-
-  def self.included(base)
-    base.send(:include, Masamune::ExampleGroup)
-    base.send(:include, Masamune::SharedExampleGroup)
-    base.send(:include, Masamune::Actions::Filesystem)
-    base.send(:include, Masamune::Actions::Hive)
-    base.send(:include, Masamune::Actions::Postgres)
-    base.send(:include, JobFixtureContext)
   end
 end
 

--- a/spec/support/masamune/mock_command.rb
+++ b/spec/support/masamune/mock_command.rb
@@ -68,15 +68,15 @@ module Masamune::MockCommand
     end
   end
 
-  included do |base|
-    base.before do
+  included do
+    before do
       new_method = Masamune::Commands::Shell.method(:new)
       allow(Masamune::Commands::Shell).to receive(:new) do |command, options|
         new_method.call(CommandMatcher.new(command), options || {})
       end
     end
 
-    base.after do
+    after do
       CommandMatcher.reset!
     end
   end

--- a/spec/support/masamune/shared_example_group.rb
+++ b/spec/support/masamune/shared_example_group.rb
@@ -34,22 +34,20 @@ module Masamune::SharedExampleGroup
     stdout.string
   end
 
-  def capture_output
-    @stdout = StringIO.new
-    @stderr = StringIO.new
+  def capture_output(stdout, stderr)
     tmp_stdout = $stdout
-    $stdout = @stdout
+    $stdout = stdout
     tmp_stderr = $stderr
-    $stderr = @stderr
+    $stderr = stderr
     yield
   ensure
     $stdout = tmp_stdout
     $stderr = tmp_stderr
   end
 
-  def capture(enable = true)
+  def capture(stdout, stderr, enable: true)
     if enable
-      capture_output do
+      capture_output(stdout, stderr) do
         yield
       end
     else

--- a/spec/support/masamune/shared_example_group.rb
+++ b/spec/support/masamune/shared_example_group.rb
@@ -45,7 +45,7 @@ module Masamune::SharedExampleGroup
     $stderr = tmp_stderr
   end
 
-  def capture(stdout, stderr, enable: true)
+  def capture(stdout: StringIO.new, stderr: StringIO.new, enable: true)
     if enable
       capture_output(stdout, stderr) do
         yield

--- a/spec/support/masamune/task_example_group.rb
+++ b/spec/support/masamune/task_example_group.rb
@@ -21,42 +21,39 @@
 #  THE SOFTWARE.
 
 module Masamune::TaskExampleGroup
-  module TaskFixtureContent
-    def self.included(base)
-      base.let!(:default_options) { configuration.as_options }
+  extend ActiveSupport::Concern
 
-      base.let(:thor_class) { described_class }
-      base.let(:command) { nil }
-      base.let(:options) { {} }
-      base.let!(:stdout) { StringIO.new }
-      base.let!(:stderr) { StringIO.new }
+  include Masamune::ExampleGroup
+  include Masamune::Actions::Filesystem
+  include Masamune::Actions::Hive
+  include Masamune::Transform::DenormalizeTable
 
-      base.let(:execute_command_times) { 1 }
+  included do |base|
+    base.let!(:default_options) { configuration.as_options }
 
-      base.subject(:execute_command) do
-        capture(stdout, stderr, enable: !default_options.include?('--debug')) do
-          execute_command_times.times do
-            Array.wrap(command).each do |cmd|
-              described_class.start([cmd, *(default_options + options)].compact)
-            end
+    base.let(:thor_class) { described_class }
+    base.let(:command) { nil }
+    base.let(:options) { {} }
+    base.let!(:stdout) { StringIO.new }
+    base.let!(:stderr) { StringIO.new }
+
+    base.let(:execute_command_times) { 1 }
+
+    base.subject(:execute_command) do
+      capture(stdout, stderr, enable: !default_options.include?('--debug')) do
+        execute_command_times.times do
+          Array.wrap(command).each do |cmd|
+            described_class.start([cmd, *(default_options + options)].compact)
           end
         end
       end
     end
-
-    shared_context 'task_fixture' do |context_options = {}|
-      include_context 'job_fixture', context_options
-
-      let(:execute_command_times) { !ENV['MASAMUNE_FASTER_SPEC'] && context_options.fetch(:idempotent, false) ? 2 : 1 }
-    end
   end
 
-  def self.included(base)
-    base.send(:include, Masamune::ExampleGroup)
-    base.send(:include, Masamune::Actions::Filesystem)
-    base.send(:include, Masamune::Actions::Hive)
-    base.send(:include, Masamune::Transform::DenormalizeTable)
-    base.send(:include, TaskFixtureContent)
+  shared_context 'task_fixture' do |context_options = {}|
+    include_context 'job_fixture', context_options
+
+    let(:execute_command_times) { !ENV['MASAMUNE_FASTER_SPEC'] && context_options.fetch(:idempotent, false) ? 2 : 1 }
   end
 end
 

--- a/spec/support/masamune/task_example_group.rb
+++ b/spec/support/masamune/task_example_group.rb
@@ -93,7 +93,7 @@ module Masamune::TaskExampleGroup
     end
 
     subject(:execute_command) do
-      capture(stdout, stderr, enable: !default_options.include?('--debug')) do
+      capture(stdout: stdout, stderr: stderr, enable: !default_options.include?('--debug')) do
         execute_command_times.times do
           thor_class.start([command, *(default_options + options)].compact)
         end

--- a/spec/support/masamune/thor_mute.rb
+++ b/spec/support/masamune/thor_mute.rb
@@ -22,7 +22,9 @@
 
 # Silence noisy and uninformative create_command method
 module Masamune::ThorMute
-  def self.included(base)
+  extend ActiveSupport::Concern
+
+  included do |base|
     base.instance_eval do
       def create_command(*a)
         tmp_stdout = $stdout

--- a/spec/support/masamune/thor_mute.rb
+++ b/spec/support/masamune/thor_mute.rb
@@ -24,8 +24,8 @@
 module Masamune::ThorMute
   extend ActiveSupport::Concern
 
-  included do |base|
-    base.instance_eval do
+  included do
+    instance_eval do
       def create_command(*a)
         tmp_stdout = $stdout
         $stdout = StringIO.new

--- a/spec/support/rspec/example/action_example_group.rb
+++ b/spec/support/rspec/example/action_example_group.rb
@@ -23,9 +23,9 @@
 module ActionExampleGroup
   extend ActiveSupport::Concern
 
-  included do |base|
-    base.let(:run_dir) { Dir.mktmpdir('masamune') }
-    base.before do
+  included do
+    let(:run_dir) { Dir.mktmpdir('masamune') }
+    before do
       instance.environment = Masamune::ExampleGroup
       Masamune::ExampleGroup.filesystem.add_path(:run_dir, run_dir)
     end

--- a/spec/support/rspec/example/action_example_group.rb
+++ b/spec/support/rspec/example/action_example_group.rb
@@ -21,7 +21,9 @@
 #  THE SOFTWARE.
 
 module ActionExampleGroup
-  def self.included(base)
+  extend ActiveSupport::Concern
+
+  included do |base|
     base.let(:run_dir) { Dir.mktmpdir('masamune') }
     base.before do
       instance.environment = Masamune::ExampleGroup

--- a/spec/support/rspec/example/task_example_group.rb
+++ b/spec/support/rspec/example/task_example_group.rb
@@ -23,77 +23,12 @@
 module TaskExampleGroup
   extend ActiveSupport::Concern
 
-  def capture(stdout, stderr)
-    tmp_stdout = $stdout
-    $stdout = stdout
-    tmp_stderr = $stderr
-    $stderr = stderr
-    yield
-  ensure
-    $stdout = tmp_stdout
-    $stderr = tmp_stderr
-  end
+  include Masamune::TaskExampleGroup
 
-  shared_examples 'general usage' do
-    it 'exits with status code 0 and prints general usage' do
-      expect { cli_invocation }.to raise_error { |e|
-        expect(e).to be_a(SystemExit)
-        expect(e.status).to eq(0)
-      }
-      expect(stdout.string).to match(/^Commands:/)
-      expect(stderr.string).to be_blank
-    end
-  end
-
-  shared_examples 'command usage' do
-    it 'exits with status code 0 and prints command usage' do
-      expect { cli_invocation }.to raise_error { |e|
-        expect(e).to be_a(SystemExit)
-        expect(e.status).to eq(0)
-      }
-      expect(stdout.string).to match(/^Usage:/)
-      expect(stdout.string).to match(/^Options:/)
-      expect(stderr.string).to be_blank
-    end
-  end
-
-  shared_examples 'executes with success' do
-    it 'exits with status code 0' do
-      expect { cli_invocation }.to raise_error { |e|
-        expect(e).to be_a(SystemExit)
-        expect(e.status).to eq(0)
-      }
-    end
-  end
-
-  shared_examples 'raises Thor::MalformattedArgumentError' do |message|
-    it { expect { cli_invocation }.to raise_error Thor::MalformattedArgumentError, message }
-  end
-
-  shared_examples 'raises Thor::RequiredArgumentMissingError' do |message|
-    it { expect { cli_invocation }.to raise_error Thor::RequiredArgumentMissingError, message }
-  end
-
-  included do |base|
-    base.before :all do
+  included do
+    before :all do
       ENV['THOR_DEBUG'] = '1'
       Masamune::Actions::DataFlow.reset_module!
-    end
-
-    base.let(:thor_class) { described_class }
-    base.let(:command) { nil }
-    base.let(:options) { {} }
-    base.let!(:stdout) { StringIO.new }
-    base.let!(:stderr) { StringIO.new }
-
-    base.before do
-      thor_class.send(:include, Masamune::ThorMute)
-    end
-
-    base.subject(:cli_invocation) do
-      capture(stdout, stderr) do
-        thor_class.start([command, *options].compact)
-      end
     end
   end
 end

--- a/spec/support/rspec/example/task_example_group.rb
+++ b/spec/support/rspec/example/task_example_group.rb
@@ -21,6 +21,8 @@
 #  THE SOFTWARE.
 
 module TaskExampleGroup
+  extend ActiveSupport::Concern
+
   def capture(stdout, stderr)
     tmp_stdout = $stdout
     $stdout = stdout
@@ -72,7 +74,7 @@ module TaskExampleGroup
     it { expect { cli_invocation }.to raise_error Thor::RequiredArgumentMissingError, message }
   end
 
-  def self.included(base)
+  included do |base|
     base.before :all do
       ENV['THOR_DEBUG'] = '1'
       Masamune::Actions::DataFlow.reset_module!

--- a/spec/support/rspec/example/transform_example_group.rb
+++ b/spec/support/rspec/example/transform_example_group.rb
@@ -21,7 +21,9 @@
 #  THE SOFTWARE.
 
 module TransformExampleGroup
-  def self.included(base)
+  extend ActiveSupport::Concern
+
+  included do |base|
     base.let(:transform) { Object.new.extend(described_class) }
     base.let(:environment) { double }
     base.let(:catalog) { Masamune::Schema::Catalog.new(environment) }

--- a/spec/support/rspec/example/transform_example_group.rb
+++ b/spec/support/rspec/example/transform_example_group.rb
@@ -23,11 +23,11 @@
 module TransformExampleGroup
   extend ActiveSupport::Concern
 
-  included do |base|
-    base.let(:transform) { Object.new.extend(described_class) }
-    base.let(:environment) { double }
-    base.let(:catalog) { Masamune::Schema::Catalog.new(environment) }
-    base.after do
+  included do
+    let(:transform) { Object.new.extend(described_class) }
+    let(:environment) { double }
+    let(:catalog) { Masamune::Schema::Catalog.new(environment) }
+    after do
       catalog.clear!
     end
   end


### PR DESCRIPTION
- Use `ActiveSupport::Concern' for all rspec example groups
- Move `execute_command` outside of `shared_context` block so that it can be used without a fixture
- Move most internal `TaskExampleGroup` code into public example group