### PR TITLE
More invoke parallel

### DIFF
--- a/lib/masamune/actions/invoke_parallel.rb
+++ b/lib/masamune/actions/invoke_parallel.rb
@@ -42,8 +42,9 @@ module Masamune::Actions
       bail_fast task_group, all_task_opts if all_task_opts[:version]
       task_group_by_task_opts = task_group.product(per_task_opts)
       Parallel.each(task_group_by_task_opts, in_processes: max_tasks) do |task_name, task_opts|
+        task_env = task_opts.delete(:env) || {}
         begin
-          execute(thor_wrapper, task_name, *task_args(all_task_opts.merge(task_opts)), interactive: true, detach: false)
+          execute(thor_wrapper, task_name, *task_args(all_task_opts.merge(task_opts)), interactive: true, detach: false, env: task_env)
         rescue SystemExit # rubocop:disable Lint/HandleExceptions
         end
       end

--- a/lib/masamune/actions/invoke_parallel.rb
+++ b/lib/masamune/actions/invoke_parallel.rb
@@ -35,8 +35,8 @@ module Masamune::Actions
     end
 
     def invoke_parallel(*task_group)
-      per_task_opts = task_group.last.is_a?(Array) ? task_group.pop.dup : [{}]
-      all_task_opts = task_group.last.is_a?(Hash) ? task_group.pop.dup : {}
+      per_task_opts = task_group.last.is_a?(Array) ? task_group.pop : [{}]
+      all_task_opts = task_group.last.is_a?(Hash) ? task_group.pop : {}
       max_tasks = [all_task_opts.delete(:max_tasks), task_group.count].min
       console("Setting max_tasks to #{max_tasks}")
       bail_fast task_group, all_task_opts if all_task_opts[:version]

--- a/lib/masamune/actions/invoke_parallel.rb
+++ b/lib/masamune/actions/invoke_parallel.rb
@@ -42,7 +42,7 @@ module Masamune::Actions
       bail_fast task_group, all_task_opts if all_task_opts[:version]
       task_group_by_task_opts = task_group.product(per_task_opts)
       Parallel.each(task_group_by_task_opts, in_processes: max_tasks) do |task_name, task_opts|
-        task_env = task_opts.delete(:env) || {}
+        task_env = task_opts[:env] || {}
         begin
           execute(thor_wrapper, task_name, *task_args(all_task_opts.merge(task_opts)), interactive: true, detach: false, env: task_env)
         rescue SystemExit # rubocop:disable Lint/HandleExceptions
@@ -58,13 +58,13 @@ module Masamune::Actions
 
     def bail_fast(task_group, opts = {})
       task_name = task_group.first
-      task_env = opts.delete(:env) || {}
+      task_env = task_opts[:env] || {}
       execute($PROGRAM_NAME, task_name, *task_args(opts), env: task_env)
       exit
     end
 
     def task_args(opts = {})
-      opts.map do |k, v|
+      opts.except(:env).map do |k, v|
         case v
         when true
           "--#{k.to_s.tr('_', '-')}"

--- a/spec/masamune/actions/aws_emr_spec.rb
+++ b/spec/masamune/actions/aws_emr_spec.rb
@@ -37,18 +37,29 @@ describe Masamune::Actions::AwsEmr do
   end
 
   describe '.aws_emr' do
-    before do
-      mock_command(/\Aaws emr/, mock_success)
+    subject(:action) { instance.aws_emr }
+
+    context 'when success' do
+      before do
+        mock_command(/\Aaws emr/, mock_success)
+      end
+
+      it { is_expected.to be_success }
     end
 
-    subject { instance.aws_emr }
+    context 'when failure' do
+      before do
+        mock_command(/\Aaws emr/, mock_failure)
+      end
 
-    it { is_expected.to be_success }
+      it { expect { action }.to raise_error RuntimeError, 'fail_fast: aws emr ssh' }
+    end
 
     context 'with retries and backoff' do
       before do
         allow(instance).to receive_message_chain(:configuration, :commands, :aws_emr).and_return(retries: 1, backoff: 10)
         expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        mock_command(/\Aaws emr/, mock_success)
       end
 
       it { is_expected.to be_success }

--- a/spec/masamune/actions/hadoop_filesystem_spec.rb
+++ b/spec/masamune/actions/hadoop_filesystem_spec.rb
@@ -31,18 +31,29 @@ describe Masamune::Actions::HadoopFilesystem do
   let(:instance) { klass.new }
 
   describe '.hadoop_filesystem' do
-    before do
-      mock_command(/\Ahadoop/, mock_success)
+    subject(:action) { instance.hadoop_filesystem }
+
+    context 'when success' do
+      before do
+        mock_command(/\Ahadoop/, mock_success)
+      end
+
+      it { is_expected.to be_success }
     end
 
-    subject { instance.hadoop_filesystem }
+    context 'when failure' do
+      before do
+        mock_command(/\Ahadoop/, mock_failure)
+      end
 
-    it { is_expected.to be_success }
+      it { is_expected.not_to be_success }
+    end
 
     context 'with retries and backoff' do
       before do
         allow(instance).to receive_message_chain(:configuration, :commands, :hadoop_filesystem).and_return(retries: 1, backoff: 10)
         expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        mock_command(/\Ahadoop/, mock_success)
       end
 
       it { is_expected.to be_success }

--- a/spec/masamune/actions/hive_spec.rb
+++ b/spec/masamune/actions/hive_spec.rb
@@ -43,18 +43,27 @@ describe Masamune::Actions::Hive do
   end
 
   describe '.hive' do
-    before do
-      mock_command(/\Ahive/, mock_success)
+    subject(:action) { instance.hive }
+
+    context 'when success' do
+      before do
+        mock_command(/\Ahive/, mock_success)
+      end
+
+      it { is_expected.to be_success }
     end
 
-    subject { instance.hive }
+    context 'when failure' do
+      before do
+        mock_command(/\Ahive/, mock_failure)
+      end
 
-    it { is_expected.to be_success }
+      it { is_expected.not_to be_success }
+    end
 
     context 'with cluster_id' do
       before do
         allow(instance).to receive_message_chain(:configuration, :commands, :aws_emr).and_return(cluster_id: 'j-XYZ')
-        mock_command(/\Ahive/, mock_failure)
         mock_command(/\Aaws emr/, mock_success, StringIO.new('ssh fakehost exit'))
         mock_command(/\Assh fakehost hive/, mock_success)
       end
@@ -68,6 +77,7 @@ describe Masamune::Actions::Hive do
       before do
         allow(instance).to receive_message_chain(:configuration, :commands, :hive).and_return(retries: 1, backoff: 10)
         expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        mock_command(/\Ahive/, mock_success)
       end
 
       it { is_expected.to be_success }

--- a/spec/masamune/actions/invoke_parallel_spec.rb
+++ b/spec/masamune/actions/invoke_parallel_spec.rb
@@ -55,5 +55,18 @@ describe Masamune::Actions::InvokeParallel do
 
       it { expect { subject }.to_not raise_error }
     end
+
+    context 'with a simple thor command and multiple environments' do
+      before do
+        mock_command(/\AMASAMUNE_ENV=test_1 thor list/, mock_success)
+        mock_command(/\AMASAMUNE_ENV=test_2 thor list/, mock_success)
+      end
+
+      subject do
+        instance.invoke_parallel('list', { max_tasks: 0 }, [{ env: { 'MASAMUNE_ENV' => 'test_1' } }, { env: { 'MASAMUNE_ENV' => 'test_2' } }])
+      end
+
+      it { expect { subject }.to_not raise_error }
+    end
   end
 end

--- a/spec/masamune/actions/invoke_parallel_spec.rb
+++ b/spec/masamune/actions/invoke_parallel_spec.rb
@@ -37,7 +37,20 @@ describe Masamune::Actions::InvokeParallel do
       end
 
       subject do
-        instance.invoke_parallel('list', max_tasks: 1)
+        instance.invoke_parallel('list', max_tasks: 0)
+      end
+
+      it { expect { subject }.to_not raise_error }
+    end
+
+    context 'with a simple thor command and multiple arguments' do
+      before do
+        mock_command(/\Athor list --a/, mock_success)
+        mock_command(/\Athor list --b/, mock_success)
+      end
+
+      subject do
+        instance.invoke_parallel('list', { max_tasks: 0 }, [{ a: true, b: false }, { a: false, b: true }])
       end
 
       it { expect { subject }.to_not raise_error }

--- a/spec/masamune/actions/invoke_parallel_spec.rb
+++ b/spec/masamune/actions/invoke_parallel_spec.rb
@@ -31,7 +31,7 @@ describe Masamune::Actions::InvokeParallel do
   let(:instance) { klass.new }
 
   describe '.invoke_parallel' do
-    context 'with a simple thor command' do
+    context 'with a single thor command' do
       before do
         mock_command(/\Athor list/, mock_success)
       end
@@ -43,7 +43,7 @@ describe Masamune::Actions::InvokeParallel do
       it { expect { subject }.to_not raise_error }
     end
 
-    context 'with a simple thor command and multiple arguments' do
+    context 'with a single thor command and multiple arguments' do
       before do
         mock_command(/\Athor list --a/, mock_success)
         mock_command(/\Athor list --b/, mock_success)
@@ -56,7 +56,7 @@ describe Masamune::Actions::InvokeParallel do
       it { expect { subject }.to_not raise_error }
     end
 
-    context 'with a simple thor command and multiple environments' do
+    context 'with a single thor command and multiple environments' do
       before do
         mock_command(/\AMASAMUNE_ENV=test_1 thor list/, mock_success)
         mock_command(/\AMASAMUNE_ENV=test_2 thor list/, mock_success)
@@ -64,6 +64,21 @@ describe Masamune::Actions::InvokeParallel do
 
       subject do
         instance.invoke_parallel('list', { max_tasks: 0 }, [{ env: { 'MASAMUNE_ENV' => 'test_1' } }, { env: { 'MASAMUNE_ENV' => 'test_2' } }])
+      end
+
+      it { expect { subject }.to_not raise_error }
+    end
+
+    context 'with a multiple thor command and multiple environments' do
+      before do
+        mock_command(/\AMASAMUNE_ENV=test_1 thor list/, mock_success)
+        mock_command(/\AMASAMUNE_ENV=test_2 thor list/, mock_success)
+        mock_command(/\AMASAMUNE_ENV=test_1 thor help/, mock_success)
+        mock_command(/\AMASAMUNE_ENV=test_2 thor help/, mock_success)
+      end
+
+      subject do
+        instance.invoke_parallel('list', 'help', { max_tasks: 0 }, [{ env: { 'MASAMUNE_ENV' => 'test_1' } }, { env: { 'MASAMUNE_ENV' => 'test_2' } }])
       end
 
       it { expect { subject }.to_not raise_error }

--- a/spec/masamune/actions/postgres_admin_spec.rb
+++ b/spec/masamune/actions/postgres_admin_spec.rb
@@ -37,7 +37,7 @@ describe Masamune::Actions::PostgresAdmin do
       let(:action) { :create }
 
       before do
-        mock_command(/\Acreatedb/, mock_success)
+        mock_command(/\APGOPTIONS=.* createdb/, mock_success)
       end
 
       it { is_expected.to be_success }
@@ -47,7 +47,7 @@ describe Masamune::Actions::PostgresAdmin do
       let(:action) { :drop }
 
       before do
-        mock_command(/\Adropdb/, mock_success)
+        mock_command(/\APGOPTIONS=.* dropdb/, mock_success)
       end
 
       it { is_expected.to be_success }

--- a/spec/masamune/actions/postgres_spec.rb
+++ b/spec/masamune/actions/postgres_spec.rb
@@ -46,18 +46,29 @@ describe Masamune::Actions::Postgres do
   end
 
   describe '.postgres' do
-    before do
-      mock_command(/\Apsql/, mock_success)
+    subject(:action) { instance.postgres }
+
+    context 'when success' do
+      before do
+        mock_command(/\APGOPTIONS=.* psql/, mock_success)
+      end
+
+      it { is_expected.to be_success }
     end
 
-    subject { instance.postgres }
+    context 'when failure' do
+      before do
+        mock_command(/\APGOPTIONS=.* psql/, mock_failure)
+      end
 
-    it { is_expected.to be_success }
+      it { is_expected.not_to be_success }
+    end
 
     context 'with retries and backoff' do
       before do
         allow(instance).to receive_message_chain(:configuration, :commands, :postgres).and_return(retries: 1, backoff: 10)
         expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        mock_command(/\APGOPTIONS=.* psql/, mock_success)
       end
 
       it { is_expected.to be_success }

--- a/spec/masamune/actions/transform_spec.rb
+++ b/spec/masamune/actions/transform_spec.rb
@@ -83,7 +83,7 @@ describe Masamune::Actions::Transform do
     context 'without :map' do
       before do
         expect_any_instance_of(Masamune::Schema::Map).to_not receive(:apply)
-        mock_command(/\Apsql/, mock_success)
+        mock_command(/\APGOPTIONS=.* psql/, mock_success)
       end
 
       it { is_expected.to be_success }
@@ -104,7 +104,7 @@ describe Masamune::Actions::Transform do
         end
 
         expect_any_instance_of(Masamune::Schema::Map).to receive(:apply).and_call_original
-        mock_command(/\Apsql/, mock_success)
+        mock_command(/\APGOPTIONS=.* psql/, mock_success)
       end
 
       it { is_expected.to be_success }
@@ -113,7 +113,7 @@ describe Masamune::Actions::Transform do
 
   describe '.relabel_dimension' do
     before do
-      mock_command(/\Apsql/, mock_success)
+      mock_command(/\APGOPTIONS=.* psql/, mock_success)
     end
 
     subject { instance.relabel_dimension(postgres.user_dimension, options) }
@@ -123,7 +123,7 @@ describe Masamune::Actions::Transform do
 
   describe '.consolidate_dimension' do
     before do
-      mock_command(/\Apsql/, mock_success)
+      mock_command(/\APGOPTIONS=.* psql/, mock_success)
     end
 
     subject { instance.consolidate_dimension(postgres.user_dimension, options) }
@@ -137,7 +137,7 @@ describe Masamune::Actions::Transform do
     context 'without :map' do
       before do
         expect_any_instance_of(Masamune::Schema::Map).to_not receive(:apply)
-        mock_command(/\Apsql/, mock_success)
+        mock_command(/\APGOPTIONS=.* psql/, mock_success)
       end
 
       subject { instance.load_fact(source_file, postgres.visits_hourly_file, postgres.visits_hourly_fact, date, options) }
@@ -152,7 +152,7 @@ describe Masamune::Actions::Transform do
         end
 
         expect_any_instance_of(Masamune::Schema::Map).to receive(:apply).and_call_original
-        mock_command(/\Apsql/, mock_success)
+        mock_command(/\APGOPTIONS=.* psql/, mock_success)
       end
 
       subject { instance.load_fact(source_file, postgres.visits_hourly_file, postgres.visits_hourly_fact, date, options) }
@@ -165,7 +165,7 @@ describe Masamune::Actions::Transform do
     let(:date) { DateTime.civil(2014, 8) }
 
     before do
-      mock_command(/\Apsql/, mock_success)
+      mock_command(/\APGOPTIONS=.* psql/, mock_success)
     end
 
     subject { instance.rollup_fact(postgres.visits_hourly_fact, postgres.visits_daily_fact, date, options) }

--- a/spec/support/masamune/mock_command.rb
+++ b/spec/support/masamune/mock_command.rb
@@ -59,6 +59,7 @@ module Masamune::MockCommand
 
     def around_execute(&block)
       self.class.patterns.each do |pattern, (value, io)|
+        logger.debug(command_env_and_args)
         next unless command_env_and_args =~ pattern
         CommandMatcher.match(pattern)
         until io.eof?

--- a/spec/support/masamune/mock_command.rb
+++ b/spec/support/masamune/mock_command.rb
@@ -52,9 +52,14 @@ module Masamune::MockCommand
       end
     end
 
+    def command_env_and_args
+      command_env = @delegate.respond_to?(:command_env) ? @delegate.command_env.map { |key, val| "#{key}=#{val}" } : []
+      (command_env + @delegate.command_args).join(' ')
+    end
+
     def around_execute(&block)
       self.class.patterns.each do |pattern, (value, io)|
-        next unless @delegate.command_args.join(' ') =~ pattern
+        next unless command_env_and_args =~ pattern
         CommandMatcher.match(pattern)
         until io.eof?
           line = io.gets

--- a/spec/support/masamune/mock_command.rb
+++ b/spec/support/masamune/mock_command.rb
@@ -59,7 +59,6 @@ module Masamune::MockCommand
 
     def around_execute(&block)
       self.class.patterns.each do |pattern, (value, io)|
-        logger.debug(command_env_and_args)
         next unless command_env_and_args =~ pattern
         CommandMatcher.match(pattern)
         until io.eof?

--- a/spec/support/masamune/mock_command.rb
+++ b/spec/support/masamune/mock_command.rb
@@ -46,11 +46,16 @@ module Masamune::MockCommand
       def reset!
         @patterns = {}
       end
+
+      def match(pattern)
+        # nop
+      end
     end
 
     def around_execute(&block)
       self.class.patterns.each do |pattern, (value, io)|
         next unless @delegate.command_args.join(' ') =~ pattern
+        CommandMatcher.match(pattern)
         until io.eof?
           line = io.gets
           line_no ||= 0
@@ -90,6 +95,7 @@ module Masamune::MockCommand
   end
 
   def mock_command(pattern, value = nil, io = StringIO.new, &block)
+    expect(CommandMatcher).to receive(:match).with(pattern)
     CommandMatcher.add_pattern(pattern, block_given? ? block.to_proc : value, io, &block)
   end
 end


### PR DESCRIPTION
- Allow `invoke_parallel` to accept per task arguments, e.g.
```
invoke_parallel 'task_1', 'task_2' { option_a: true }, { [ { option_b: true } ], [ {option_b: false} ] }
```
will result in following parallel execution:
```
invoke 'task_1', {option_a: true, option_b: true}
invoke 'task_1', {option_a: true, option_b: false}
invoke 'task_2', {option_a: true, option_b: true}
invoke 'task_2', {option_a: true, option_b: false}
```

- Handle `:env` option correctly, e.g. do not try to convert it into an option, instead set environment variables

- ensure that `mock_command` executes (necessary to test this change)