### PR TITLE
Revert remove dup

### DIFF
--- a/lib/masamune/actions/invoke_parallel.rb
+++ b/lib/masamune/actions/invoke_parallel.rb
@@ -35,8 +35,8 @@ module Masamune::Actions
     end
 
     def invoke_parallel(*task_group)
-      per_task_opts = task_group.last.is_a?(Array) ? task_group.pop : [{}]
-      all_task_opts = task_group.last.is_a?(Hash) ? task_group.pop : {}
+      per_task_opts = task_group.last.is_a?(Array) ? task_group.pop.dup : [{}]
+      all_task_opts = task_group.last.is_a?(Hash) ? task_group.pop.dup : {}
       max_tasks = [all_task_opts.delete(:max_tasks), task_group.count].min
       console("Setting max_tasks to #{max_tasks}")
       bail_fast task_group, all_task_opts if all_task_opts[:version]

--- a/spec/masamune/actions/invoke_parallel_spec.rb
+++ b/spec/masamune/actions/invoke_parallel_spec.rb
@@ -29,6 +29,7 @@ describe Masamune::Actions::InvokeParallel do
   end
 
   let(:instance) { klass.new }
+  let(:task_opts) { { max_tasks: 0 }.freeze }
 
   describe '.invoke_parallel' do
     context 'with a single thor command' do
@@ -37,7 +38,7 @@ describe Masamune::Actions::InvokeParallel do
       end
 
       subject do
-        instance.invoke_parallel('list', max_tasks: 0)
+        instance.invoke_parallel('list', task_opts)
       end
 
       it { expect { subject }.to_not raise_error }
@@ -50,7 +51,7 @@ describe Masamune::Actions::InvokeParallel do
       end
 
       subject do
-        instance.invoke_parallel('list', { max_tasks: 0 }, [{ a: true, b: false }, { a: false, b: true }])
+        instance.invoke_parallel('list', task_opts, [{ a: true, b: false }, { a: false, b: true }])
       end
 
       it { expect { subject }.to_not raise_error }
@@ -63,7 +64,7 @@ describe Masamune::Actions::InvokeParallel do
       end
 
       subject do
-        instance.invoke_parallel('list', { max_tasks: 0 }, [{ env: { 'MASAMUNE_ENV' => 'test_1' } }, { env: { 'MASAMUNE_ENV' => 'test_2' } }])
+        instance.invoke_parallel('list', task_opts, [{ env: { 'MASAMUNE_ENV' => 'test_1' } }, { env: { 'MASAMUNE_ENV' => 'test_2' } }])
       end
 
       it { expect { subject }.to_not raise_error }
@@ -78,7 +79,7 @@ describe Masamune::Actions::InvokeParallel do
       end
 
       subject do
-        instance.invoke_parallel('list', 'help', { max_tasks: 0 }, [{ env: { 'MASAMUNE_ENV' => 'test_1' } }, { env: { 'MASAMUNE_ENV' => 'test_2' } }])
+        instance.invoke_parallel('list', 'help', task_opts, [{ env: { 'MASAMUNE_ENV' => 'test_1' } }, { env: { 'MASAMUNE_ENV' => 'test_2' } }])
       end
 
       it { expect { subject }.to_not raise_error }


### PR DESCRIPTION
@eatstoomuchjam apparently the `dup` is necessary since the `Thor` options hash is frozen. I added a spec to prevent regression.
```
E, [2016-08-23T22:47:03.763497 #9111] ERROR -- : can't modify frozen Thor::CoreExt::HashWithIndifferentAccess (RuntimeError) backtrace:
E, [2016-08-23T22:47:03.763624 #9111] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/core_ext/hash_with_indifferent_access.rb:28:in `delete'
E, [2016-08-23T22:47:03.763674 #9111] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/core_ext/hash_with_indifferent_access.rb:28:in `delete'
E, [2016-08-23T22:47:03.763720 #9111] ERROR -- : /usr/lib/ruby/gems/2.2.0/gems/masamune-0.18.2/lib/masamune/actions/invoke_parallel.rb:40:in `invoke_parallel'
```