### PR TITLE
Limit cache depth to not exceed max free parameters

### DIFF
--- a/lib/masamune/data_plan/rule.rb
+++ b/lib/masamune/data_plan/rule.rb
@@ -253,6 +253,16 @@ class Masamune::DataPlan::Rule
   end
 
   def cache_depth
+    [max_cache_depth, step_cache_depth].min
+  end
+
+  private
+
+  def max_cache_depth
+    pattern.split('/').select { |x| x.include?('%') || x.include?('*') }.count
+  end
+
+  def step_cache_depth
     case time_step
     when :hour, :hours
       2
@@ -262,8 +272,6 @@ class Masamune::DataPlan::Rule
       0
     end
   end
-
-  private
 
   def time_step_to_format(step)
     case step

--- a/spec/masamune/data_plan/rule_spec.rb
+++ b/spec/masamune/data_plan/rule_spec.rb
@@ -464,4 +464,48 @@ describe Masamune::DataPlan::Rule do
       it { is_expected.to be(true) }
     end
   end
+
+  describe '#cache_depth' do
+    subject { instance.cache_depth }
+
+    context 'with flat glob' do
+      let(:pattern) { 'logs/*.log' }
+      it { is_expected.to be(1) }
+    end
+
+    context 'with nested glob' do
+      let(:pattern) { 'logs/%Y-%m-%d/*.log' }
+      it { is_expected.to be(1) }
+    end
+
+    context 'with flat :hourly' do
+      let(:pattern) { 'logs/*%H-s.log' }
+      it { is_expected.to be(1) }
+    end
+
+    context 'with nested :hourly' do
+      let(:pattern) { 'report/%Y-%m-%d/%H' }
+      it { is_expected.to be(2) }
+    end
+
+    context 'with flat :daily' do
+      let(:pattern) { 'report/%Y-%m-%d' }
+      it { is_expected.to be(1) }
+    end
+
+    context 'with nested :daily' do
+      let(:pattern) { 'report/%Y-%m/%d' }
+      it { is_expected.to be(1) }
+    end
+
+    context 'with flat :monthly' do
+      let(:pattern) { 'report/%Y-%m' }
+      it { is_expected.to be(0) }
+    end
+
+    context 'with nested :monthly' do
+      let(:pattern) { 'report/%Y/%m' }
+      it { is_expected.to be(0) }
+    end
+  end
 end


### PR DESCRIPTION
In order to efficiently check for existence of remote files, the code attempts to batch together a multiple scans into a single request based on the granularity.  For example, if it is checking for files in `logs/y=YEAR/m=MONTH/d=DAY/h=HOUR` it expects to scan many files and instead performs a single request to get all files that match `logs/y=YEAR/m=MONTH/**/*`. The parameter that is controlling the recursive depth is `cache_depth` and for hourly grain it is always set to 2. There are some cases when this behavior negatively impacts performance, for example if the file pattern is `bucket/env/logs/%H-s.*.log` then the code will scan `bucket/env/**/*` which is obviously unnecessary and bad for performance. This change limits the `cache_depth` to the maximum number free parameters in the expression to prevent this behavior.