### PR TITLE
Try to make stty sane again

### DIFF
--- a/lib/masamune/commands/shell.rb
+++ b/lib/masamune/commands/shell.rb
@@ -47,6 +47,7 @@ module Masamune::Commands
       around_execute do
         pid = Process.fork
         if pid
+          Signal.trap('INT') {} # Ensure SIGINT is handled by child process exec
           detach if opts.fetch(:detach, true)
           Process.waitpid(pid)
           exit

--- a/lib/masamune/commands/shell.rb
+++ b/lib/masamune/commands/shell.rb
@@ -144,7 +144,6 @@ module Masamune::Commands
 
         [t_stderr, t_stdout, t_stdin].compact.each(&:join)
         logger.debug("status: #{t_stdin.value}")
-        `stty sane -F /dev/tty` if RUBY_PLATFORM =~ /linux/
         t_stdin.value
       end
     end


### PR DESCRIPTION
[While trying to fix this behavior in last PR](https://github.com/socialcast/masamune/pull/195) - I noticed that stty sane caused issues with readline.  This only really needs to be issued once - after the child process has exited. 