### PR TITLE
Allow yaml sub_type

### DIFF
--- a/lib/masamune/schema/column.rb
+++ b/lib/masamune/schema/column.rb
@@ -278,7 +278,7 @@ module Masamune::Schema
         when Hash
           value
         when String
-          YAML.safe_load(value, [Symbol])
+          YAML.safe_load(value, allowed_yaml_sub_type)
         when nil
           {}
         end
@@ -491,6 +491,10 @@ module Masamune::Schema
       else
         [ruby_value(value, false)].to_json
       end
+    end
+
+    def allowed_yaml_sub_type
+      @allowed_yaml_sub_type ||= [Symbol] + Array.wrap(sub_type)
     end
   end
 end

--- a/spec/masamune/schema/map_spec.rb
+++ b/spec/masamune/schema/map_spec.rb
@@ -446,6 +446,87 @@ describe Masamune::Schema::Map do
       it_behaves_like 'apply input/output'
     end
 
+    context 'from csv file to tsv file with unknown yaml sub_type' do
+      before do
+        expect(environment.logger).to receive(:warn).with(/Could not coerce/).ordered
+        expect(environment.logger).to receive(:debug).with(
+          message: "Could not coerce '--- !map:ActiveSupport::HashWithIndifferentAccess\nenabled: true\n' into :yaml for column 'preferences'",
+          source: 'input_stage',
+          target: 'output_stage',
+          file: input.path,
+          line: 1,
+          row: {
+            'id'          => '2',
+            'tenant_id'   => '40',
+            'deleted_at'  => '2014-02-26T18:15:51.000Z',
+            'admin'       => 'FALSE',
+            'preferences' => "--- !map:ActiveSupport::HashWithIndifferentAccess\nenabled: true\n"
+          }
+        ).ordered
+      end
+
+      before do
+        catalog.schema :files do
+          file 'input', format: :csv, headers: true, json_encoding: :quoted do
+            column 'id', type: :integer
+            column 'tenant_id', type: :integer
+            column 'admin', type: :boolean
+            column 'preferences', type: :yaml
+            column 'deleted_at', type: :timestamp, null: true
+          end
+
+          file 'output', format: :tsv, headers: false do
+            column 'id', type: :integer
+            column 'tenant_id', type: :integer
+            column 'admin', type: :boolean
+            column 'preferences', type: :json
+            column 'deleted_at', type: :timestamp, null: true
+          end
+
+          map from: files.input, to: files.output do |row|
+            {
+              'id'          => row[:id],
+              'tenant_id'   => row[:tenant_id],
+              'deleted_at'  => row[:deleted_at],
+              'admin'       => row[:admin],
+              'preferences' => row[:preferences]
+            }
+          end
+        end
+      end
+
+      let(:source) do
+        catalog.files.input
+      end
+
+      let(:target) do
+        catalog.files.output
+      end
+
+      let(:source_data) do
+        <<-EOS.strip_heredoc
+          id,tenant_id,deleted_at,admin,preferences
+          1,30,,FALSE,"--- {}
+          "
+          2,40,2014-02-26T18:15:51.000Z,FALSE,"--- !map:ActiveSupport::HashWithIndifferentAccess
+          enabled: true
+          "
+        EOS
+      end
+
+      let(:target_data) do
+        <<-EOS.strip_heredoc
+          1	30		FALSE	{}
+        EOS
+      end
+
+      it 'should match target data' do
+        is_expected.to eq(target_data)
+      end
+
+      it_behaves_like 'apply input/output'
+    end
+
     context 'with multiple outputs' do
       before do
         catalog.schema :files do


### PR DESCRIPTION
RuboCop recently corrected a [security related offense](https://github.com/socialcast/masamune/pull/200). However, in some cases the end user might want to explicitly allow certain ruby classes to be deserialized from YAML. This PR allows specific classes to be specified on a per column basis.  