### PR TITLE
renamed retires to max_retries

### DIFF
--- a/lib/masamune/actions/aws_emr.rb
+++ b/lib/masamune/actions/aws_emr.rb
@@ -28,7 +28,7 @@ module Masamune::Actions
       opts = opts.to_hash.symbolize_keys
 
       command = Masamune::Commands::AwsEmr.new(environment, opts)
-      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.aws_emr.slice(:retries, :backoff).merge(opts))
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.aws_emr.slice(:max_retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.interactive? ? command.replace : command.execute

--- a/lib/masamune/actions/hadoop_filesystem.rb
+++ b/lib/masamune/actions/hadoop_filesystem.rb
@@ -30,7 +30,7 @@ module Masamune::Actions
       opts[:block] = block.to_proc if block_given?
 
       command = Masamune::Commands::HadoopFilesystem.new(environment, opts)
-      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.hadoop_filesystem.slice(:retries, :backoff).merge(opts))
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.hadoop_filesystem.slice(:max_retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.execute

--- a/lib/masamune/actions/hadoop_streaming.rb
+++ b/lib/masamune/actions/hadoop_streaming.rb
@@ -27,7 +27,7 @@ module Masamune::Actions
 
       command = Masamune::Commands::HadoopStreaming.new(environment, aws_emr_options(opts))
       command = Masamune::Commands::AwsEmr.new(command, opts.except(:extra)) if configuration.commands.aws_emr[:cluster_id]
-      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.hadoop_streaming.slice(:retries, :backoff).merge(opts))
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.hadoop_streaming.slice(:max_retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.execute

--- a/lib/masamune/actions/hive.rb
+++ b/lib/masamune/actions/hive.rb
@@ -34,7 +34,7 @@ module Masamune::Actions
 
       command = Masamune::Commands::Hive.new(environment, opts)
       command = Masamune::Commands::AwsEmr.new(command, opts.except(:extra)) if configuration.commands.aws_emr[:cluster_id]
-      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.hive.slice(:retries, :backoff).merge(opts))
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.hive.slice(:max_retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.interactive? ? command.replace : command.execute

--- a/lib/masamune/actions/postgres.rb
+++ b/lib/masamune/actions/postgres.rb
@@ -35,7 +35,7 @@ module Masamune::Actions
       opts[:block] = block.to_proc if block_given?
 
       command = Masamune::Commands::Postgres.new(environment, opts)
-      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.postgres.slice(:retries, :backoff).merge(opts))
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.postgres.slice(:max_retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.interactive? ? command.replace : command.execute
@@ -51,14 +51,14 @@ module Masamune::Actions
       return unless configuration.commands.postgres.key?(:setup_files)
       configuration.commands.postgres[:setup_files].each do |file|
         configuration.with_quiet do
-          postgres(file: file, retries: 0)
+          postgres(file: file, max_retries: 0)
         end
       end
     end
 
     def load_postgres_schema
       transform = define_schema(catalog, :postgres)
-      postgres(file: transform.to_file, retries: 0)
+      postgres(file: transform.to_file, max_retries: 0)
     rescue => e
       logger.error(e)
       logger.error('Could not load schema')

--- a/lib/masamune/actions/postgres_admin.rb
+++ b/lib/masamune/actions/postgres_admin.rb
@@ -35,7 +35,7 @@ module Masamune::Actions
     private
 
     def postgres_admin_retry_with_backoff_options
-      configuration.commands.postgres.merge(configuration.commands.postgres_admin).slice(:retries, :backoff)
+      configuration.commands.postgres.merge(configuration.commands.postgres_admin).slice(:max_retries, :backoff)
     end
   end
 end

--- a/lib/masamune/actions/s3cmd.rb
+++ b/lib/masamune/actions/s3cmd.rb
@@ -33,7 +33,7 @@ module Masamune::Actions
       opts[:block] = block.to_proc if block_given?
 
       command = Masamune::Commands::S3Cmd.new(environment, opts)
-      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.s3cmd.slice(:retries, :backoff).merge(opts))
+      command = Masamune::Commands::RetryWithBackoff.new(command, configuration.commands.s3cmd.slice(:max_retries, :backoff).merge(opts))
       command = Masamune::Commands::Shell.new(command, opts)
 
       command.execute

--- a/lib/masamune/commands/retry_with_backoff.rb
+++ b/lib/masamune/commands/retry_with_backoff.rb
@@ -29,7 +29,7 @@ module Masamune::Commands
     def initialize(delegate, attrs = {})
       super delegate
       @delegate     = delegate
-      @retries      = attrs.fetch(:retries, configuration.retries)
+      @max_retries      = attrs.fetch(:max_retries, configuration.max_retries)
       @backoff      = attrs.fetch(:backoff, configuration.backoff)
       @retry_count  = 0
     end
@@ -48,11 +48,11 @@ module Masamune::Commands
       logger.error(e.to_s)
       sleep @backoff
       @retry_count += 1
-      if @retry_count > @retries
-        logger.debug("max retries (#{@retries}) attempted, bailing")
+      if @retry_count > @max_retries
+        logger.debug("max retries (#{@max_retries}) attempted, bailing")
         OpenStruct.new(success?: false, exitstatus: MAX_RETRY_EXIT_STATUS)
       else
-        logger.debug("retrying (#{@retry_count}/#{@retries})")
+        logger.debug("retrying (#{@retry_count}/#{@max_retries})")
         retry
       end
     end

--- a/lib/masamune/commands/retry_with_backoff.rb
+++ b/lib/masamune/commands/retry_with_backoff.rb
@@ -28,8 +28,8 @@ module Masamune::Commands
 
     def initialize(delegate, attrs = {})
       super delegate
-      @delegate     = delegate
-      @max_retries      = attrs.fetch(:max_retries, configuration.max_retries)
+      @delegate = delegate
+      @max_retries = attrs.fetch(:max_retries, configuration.max_retries)
       @backoff      = attrs.fetch(:backoff, configuration.backoff)
       @retry_count  = 0
     end

--- a/lib/masamune/configuration.rb
+++ b/lib/masamune/configuration.rb
@@ -56,7 +56,7 @@ class Masamune::Configuration < Hashie::Dash
   property :debug, default: false
   property :dry_run, default: false
   property :lock
-  property :retries, default: 3
+  property :max_retries, default: 3
   property :backoff, default: 5
   property :params, default: Hashie::Mash.new
   property :commands, default: Hashie::Mash.new { |h, k| h[k] = Hashie::Mash.new }

--- a/lib/masamune/helpers/postgres.rb
+++ b/lib/masamune/helpers/postgres.rb
@@ -39,7 +39,7 @@ module Masamune::Helpers
     end
 
     def database_exists?
-      @database_exists ||= postgres(exec: 'SELECT version();', fail_fast: false, retries: 0).success?
+      @database_exists ||= postgres(exec: 'SELECT version();', fail_fast: false, max_retries: 0).success?
     end
 
     def table_exists?(table)
@@ -64,7 +64,7 @@ module Masamune::Helpers
 
     def update_tables
       return unless @cache.empty?
-      postgres(exec: 'SELECT table_name FROM information_schema.tables;', tuple_output: true, retries: 0) do |line|
+      postgres(exec: 'SELECT table_name FROM information_schema.tables;', tuple_output: true, max_retries: 0) do |line|
         table = line.strip
         next if table.start_with?('pg_')
         @cache[table] ||= nil
@@ -73,7 +73,7 @@ module Masamune::Helpers
 
     def update_table_last_modified_at(table, column)
       return if @cache[table].present?
-      postgres(exec: "SELECT MAX(#{column}) FROM #{table};", tuple_output: true, retries: 0) do |line|
+      postgres(exec: "SELECT MAX(#{column}) FROM #{table};", tuple_output: true, max_retries: 0) do |line|
         last_modified_at = line.strip
         @cache[table] = parse_date_time(last_modified_at) unless last_modified_at.blank?
       end

--- a/lib/masamune/tasks/hive_thor.rb
+++ b/lib/masamune/tasks/hive_thor.rb
@@ -46,7 +46,7 @@ module Masamune::Tasks
     def hive_exec
       hive_options = options.dup.with_indifferent_access
       hive_options[:print] = true
-      hive_options[:retries] = 0 unless options[:retry]
+      hive_options[:max_retries] = 0 unless options[:retry]
       hive_options[:file] = File.expand_path(options[:file]) if options[:file]
       hive_options[:output] = File.expand_path(options[:output]) if options[:output]
       hive(hive_options)

--- a/lib/masamune/tasks/postgres_thor.rb
+++ b/lib/masamune/tasks/postgres_thor.rb
@@ -42,7 +42,7 @@ module Masamune::Tasks
     def psql_exec
       postgres_options = options.dup.with_indifferent_access
       postgres_options[:print] = true
-      postgres_options[:retries] = 0 unless options[:retry]
+      postgres_options[:max_retries] = 0 unless options[:retry]
       postgres(postgres_options)
     end
     default_task :psql_exec

--- a/spec/masamune/actions/aws_emr_spec.rb
+++ b/spec/masamune/actions/aws_emr_spec.rb
@@ -55,10 +55,10 @@ describe Masamune::Actions::AwsEmr do
       it { expect { action }.to raise_error RuntimeError, 'fail_fast: aws emr ssh' }
     end
 
-    context 'with retries and backoff' do
+    context 'with max_retries and backoff' do
       before do
-        allow(instance).to receive_message_chain(:configuration, :commands, :aws_emr).and_return(retries: 1, backoff: 10)
-        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        allow(instance).to receive_message_chain(:configuration, :commands, :aws_emr).and_return(max_retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(max_retries: 1, backoff: 10)).once.and_call_original
         mock_command(/\Aaws emr/, mock_success)
       end
 

--- a/spec/masamune/actions/hadoop_filesystem_spec.rb
+++ b/spec/masamune/actions/hadoop_filesystem_spec.rb
@@ -49,10 +49,10 @@ describe Masamune::Actions::HadoopFilesystem do
       it { is_expected.not_to be_success }
     end
 
-    context 'with retries and backoff' do
+    context 'with max_retries and backoff' do
       before do
-        allow(instance).to receive_message_chain(:configuration, :commands, :hadoop_filesystem).and_return(retries: 1, backoff: 10)
-        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        allow(instance).to receive_message_chain(:configuration, :commands, :hadoop_filesystem).and_return(max_retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(max_retries: 1, backoff: 10)).once.and_call_original
         mock_command(/\Ahadoop/, mock_success)
       end
 

--- a/spec/masamune/actions/hadoop_streaming_spec.rb
+++ b/spec/masamune/actions/hadoop_streaming_spec.rb
@@ -77,10 +77,10 @@ describe Masamune::Actions::HadoopStreaming do
       it { is_expected.to be_success }
     end
 
-    context 'with retries and backoff' do
+    context 'with max_retries and backoff' do
       before do
-        allow(instance).to receive_message_chain(:configuration, :commands, :hadoop_streaming).and_return(retries: 1, backoff: 10)
-        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        allow(instance).to receive_message_chain(:configuration, :commands, :hadoop_streaming).and_return(max_retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(max_retries: 1, backoff: 10)).once.and_call_original
         mock_command(/\Ahadoop/, mock_success)
       end
 

--- a/spec/masamune/actions/hive_spec.rb
+++ b/spec/masamune/actions/hive_spec.rb
@@ -73,10 +73,10 @@ describe Masamune::Actions::Hive do
       it { is_expected.to be_success }
     end
 
-    context 'with retries and backoff' do
+    context 'with max_retries and backoff' do
       before do
-        allow(instance).to receive_message_chain(:configuration, :commands, :hive).and_return(retries: 1, backoff: 10)
-        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        allow(instance).to receive_message_chain(:configuration, :commands, :hive).and_return(max_retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(max_retries: 1, backoff: 10)).once.and_call_original
         mock_command(/\Ahive/, mock_success)
       end
 

--- a/spec/masamune/actions/postgres_admin_spec.rb
+++ b/spec/masamune/actions/postgres_admin_spec.rb
@@ -30,22 +30,22 @@ describe Masamune::Actions::PostgresAdmin do
 
   let(:instance) { klass.new }
 
-  shared_context 'retries and backoff' do
-    context 'with retries and backoff configured via postgres_admin command' do
+  shared_context 'max_retries and backoff' do
+    context 'with max_retries and backoff configured via postgres_admin command' do
       before do
-        allow(instance).to receive_message_chain(:configuration, :commands, :postgres).and_return(retries: 1, backoff: 10)
-        allow(instance).to receive_message_chain(:configuration, :commands, :postgres_admin).and_return(retries: 3, backoff: 1)
-        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 3, backoff: 1)).once.and_call_original
+        allow(instance).to receive_message_chain(:configuration, :commands, :postgres).and_return(max_retries: 1, backoff: 10)
+        allow(instance).to receive_message_chain(:configuration, :commands, :postgres_admin).and_return(max_retries: 3, backoff: 1)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(max_retries: 3, backoff: 1)).once.and_call_original
       end
 
       it { is_expected.to be_success }
     end
 
-    context 'with retries and backoff configured via postgres command' do
+    context 'with max_retries and backoff configured via postgres command' do
       before do
-        allow(instance).to receive_message_chain(:configuration, :commands, :postgres).and_return(retries: 1, backoff: 10)
+        allow(instance).to receive_message_chain(:configuration, :commands, :postgres).and_return(max_retries: 1, backoff: 10)
         allow(instance).to receive_message_chain(:configuration, :commands, :postgres_admin).and_return({})
-        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(max_retries: 1, backoff: 10)).once.and_call_original
       end
 
       it { is_expected.to be_success }
@@ -64,7 +64,7 @@ describe Masamune::Actions::PostgresAdmin do
 
       it { is_expected.to be_success }
 
-      include_context 'retries and backoff'
+      include_context 'max_retries and backoff'
     end
 
     context 'with :action :drop' do
@@ -76,7 +76,7 @@ describe Masamune::Actions::PostgresAdmin do
 
       it { is_expected.to be_success }
 
-      include_context 'retries and backoff'
+      include_context 'max_retries and backoff'
     end
   end
 end

--- a/spec/masamune/actions/postgres_spec.rb
+++ b/spec/masamune/actions/postgres_spec.rb
@@ -64,10 +64,10 @@ describe Masamune::Actions::Postgres do
       it { is_expected.not_to be_success }
     end
 
-    context 'with retries and backoff' do
+    context 'with max_retries and backoff' do
       before do
-        allow(instance).to receive_message_chain(:configuration, :commands, :postgres).and_return(retries: 1, backoff: 10)
-        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        allow(instance).to receive_message_chain(:configuration, :commands, :postgres).and_return(max_retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(max_retries: 1, backoff: 10)).once.and_call_original
         mock_command(/\APGOPTIONS=.* psql/, mock_success)
       end
 
@@ -100,7 +100,7 @@ describe Masamune::Actions::Postgres do
       before do
         expect(postgres_helper).to receive(:database_exists?).and_return(false)
         expect(instance).to receive(:postgres_admin).with(action: :create, database: 'test', safe: true).once
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', max_retries: 0).once
         after_initialize_invoke
       end
       it 'should call posgres_admin once' do
@@ -111,7 +111,7 @@ describe Masamune::Actions::Postgres do
       before do
         expect(postgres_helper).to receive(:database_exists?).and_return(true)
         expect(instance).to receive(:postgres_admin).never
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', max_retries: 0).once
         after_initialize_invoke
       end
       it 'should not call postgres_admin' do
@@ -122,8 +122,8 @@ describe Masamune::Actions::Postgres do
       let(:setup_files) { ['setup.psql'] }
       before do
         expect(postgres_helper).to receive(:database_exists?).and_return(true)
-        expect(instance).to receive(:postgres).with(file: setup_files.first, retries: 0).once
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
+        expect(instance).to receive(:postgres).with(file: setup_files.first, max_retries: 0).once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', max_retries: 0).once
         after_initialize_invoke
       end
       it 'should call postgres with setup_files' do
@@ -147,7 +147,7 @@ describe Masamune::Actions::Postgres do
       before do
         filesystem.touch!('schema_1.psql', 'schema_2.psql')
         expect(postgres_helper).to receive(:database_exists?).and_return(true)
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', max_retries: 0).once
         after_initialize_invoke
       end
       it 'should call postgres with schema_files' do
@@ -159,7 +159,7 @@ describe Masamune::Actions::Postgres do
       before do
         filesystem.touch!('schema.rb')
         expect(postgres_helper).to receive(:database_exists?).and_return(true)
-        expect(instance).to receive(:postgres).with(file: 'catalog.psql', retries: 0).once
+        expect(instance).to receive(:postgres).with(file: 'catalog.psql', max_retries: 0).once
         after_initialize_invoke
       end
       it 'should call postgres with schema_files' do

--- a/spec/masamune/actions/s3cmd_spec.rb
+++ b/spec/masamune/actions/s3cmd_spec.rb
@@ -39,10 +39,10 @@ describe Masamune::Actions::S3Cmd do
 
     it { is_expected.to be_success }
 
-    context 'with retries and backoff' do
+    context 'with max_retries and backoff' do
       before do
-        allow(instance).to receive_message_chain(:configuration, :commands, :s3cmd).and_return(retries: 1, backoff: 10)
-        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(retries: 1, backoff: 10)).once.and_call_original
+        allow(instance).to receive_message_chain(:configuration, :commands, :s3cmd).and_return(max_retries: 1, backoff: 10)
+        expect(Masamune::Commands::RetryWithBackoff).to receive(:new).with(anything, hash_including(max_retries: 1, backoff: 10)).once.and_call_original
       end
 
       it { is_expected.to be_success }

--- a/spec/masamune/commands/retry_with_backoff_spec.rb
+++ b/spec/masamune/commands/retry_with_backoff_spec.rb
@@ -21,7 +21,7 @@
 #  THE SOFTWARE.
 
 describe Masamune::Commands::RetryWithBackoff do
-  let(:options) { {max_retries: max_retries, backoff: 0 } }
+  let(:options) { { max_retries: max_retries, backoff: 0 } }
   let(:delegate) { double }
   let(:instance) { described_class.new(delegate, options) }
 

--- a/spec/masamune/commands/retry_with_backoff_spec.rb
+++ b/spec/masamune/commands/retry_with_backoff_spec.rb
@@ -21,22 +21,22 @@
 #  THE SOFTWARE.
 
 describe Masamune::Commands::RetryWithBackoff do
-  let(:options) { { retries: retries, backoff: 0 } }
+  let(:options) { {max_retries: max_retries, backoff: 0 } }
   let(:delegate) { double }
   let(:instance) { described_class.new(delegate, options) }
 
   before do
     allow(delegate).to receive(:logger).and_return(double)
-    allow(delegate).to receive(:configuration).and_return(double(retries: 0, backoff: 0))
+    allow(delegate).to receive(:configuration).and_return(double(max_retries: 0, backoff: 0))
   end
 
   describe '#around_execute' do
-    let(:retries) { 3 }
+    let(:max_retries) { 3 }
 
     context 'when retry command fails with status but eventually succeeds' do
       before do
-        expect(instance.logger).to receive(:error).with('exited with code: 42').exactly(retries - 1)
-        expect(instance.logger).to receive(:debug).with(/retrying.*/).exactly(retries - 1)
+        expect(instance.logger).to receive(:error).with('exited with code: 42').exactly(max_retries - 1)
+        expect(instance.logger).to receive(:debug).with(/retrying.*/).exactly(max_retries - 1)
         subject
       end
 
@@ -44,7 +44,7 @@ describe Masamune::Commands::RetryWithBackoff do
         @retry_count = 0
         instance.around_execute do
           @retry_count += 1
-          if @retry_count < retries
+          if @retry_count < max_retries
             OpenStruct.new(success?: false, exitstatus: 42)
           else
             OpenStruct.new(success?: true)
@@ -55,7 +55,7 @@ describe Masamune::Commands::RetryWithBackoff do
       it 'logs useful debug and error messages' do
       end
       it 'attempts to retry the specified number of times' do
-        expect(@retry_count).to eq(retries)
+        expect(@retry_count).to eq(max_retries)
       end
       it 'returns result status' do
         is_expected.to be_success
@@ -64,8 +64,8 @@ describe Masamune::Commands::RetryWithBackoff do
 
     context 'when retry command fails with exception but eventually succeeds' do
       before do
-        expect(instance.logger).to receive(:error).with('wtf').exactly(retries - 1)
-        expect(instance.logger).to receive(:debug).with(/retrying.*/).exactly(retries - 1)
+        expect(instance.logger).to receive(:error).with('wtf').exactly(max_retries - 1)
+        expect(instance.logger).to receive(:debug).with(/retrying.*/).exactly(max_retries - 1)
         subject
       end
 
@@ -73,7 +73,7 @@ describe Masamune::Commands::RetryWithBackoff do
         @retry_count = 0
         instance.around_execute do
           @retry_count += 1
-          raise 'wtf' if @retry_count < retries
+          raise 'wtf' if @retry_count < max_retries
           OpenStruct.new(success?: true)
         end
       end
@@ -81,7 +81,7 @@ describe Masamune::Commands::RetryWithBackoff do
       it 'logs useful debug and error messages' do
       end
       it 'attempts to retry the specified number of times' do
-        expect(@retry_count).to eq(retries)
+        expect(@retry_count).to eq(max_retries)
       end
       it 'returns result status' do
         is_expected.to be_success
@@ -90,8 +90,8 @@ describe Masamune::Commands::RetryWithBackoff do
 
     context 'when retry command eventually fails' do
       before do
-        expect(instance.logger).to receive(:error).with('wtf').exactly(retries + 1)
-        expect(instance.logger).to receive(:debug).with(/retrying.*/).exactly(retries)
+        expect(instance.logger).to receive(:error).with('wtf').exactly(max_retries + 1)
+        expect(instance.logger).to receive(:debug).with(/retrying.*/).exactly(max_retries)
         expect(instance.logger).to receive(:debug).with(/max retries.*bailing/)
         subject
       end
@@ -107,7 +107,7 @@ describe Masamune::Commands::RetryWithBackoff do
       it 'logs useful debug and error messages' do
       end
       it 'attempts to retry the specified number of times' do
-        expect(@retry_count).to eq(retries + 1)
+        expect(@retry_count).to eq(max_retries + 1)
       end
       it 'returns failure status' do
         is_expected.not_to be_success

--- a/spec/masamune/filesystem_spec.rb
+++ b/spec/masamune/filesystem_spec.rb
@@ -36,7 +36,7 @@ shared_examples_for 'Filesystem' do
   let(:old_file) { File.join(old_dir, SecureRandom.hex + '.txt') }
 
   before do
-    filesystem.configuration.retries = 0
+    filesystem.configuration.max_retries = 0
     FileUtils.mkdir_p(old_dir)
     FileUtils.touch(old_file)
   end

--- a/spec/masamune/helpers/postgres_spec.rb
+++ b/spec/masamune/helpers/postgres_spec.rb
@@ -28,7 +28,7 @@ describe Masamune::Helpers::Postgres do
     let(:mock_status) {}
 
     before do
-      expect(instance).to receive(:postgres).with(hash_including(exec: 'SELECT version();', fail_fast: false, retries: 0)).and_return(mock_status)
+      expect(instance).to receive(:postgres).with(hash_including(exec: 'SELECT version();', fail_fast: false, max_retries: 0)).and_return(mock_status)
     end
 
     subject { instance.database_exists? }
@@ -47,7 +47,7 @@ describe Masamune::Helpers::Postgres do
   describe '#table_exists' do
     before do
       expect(instance).to receive(:database_exists?).and_return(true)
-      expect(instance).to receive(:postgres).with(hash_including(exec: 'SELECT table_name FROM information_schema.tables;', tuple_output: true, retries: 0)).and_yield('  foo').and_yield('  bar').and_yield('  baz')
+      expect(instance).to receive(:postgres).with(hash_including(exec: 'SELECT table_name FROM information_schema.tables;', tuple_output: true, max_retries: 0)).and_yield('  foo').and_yield('  bar').and_yield('  baz')
     end
 
     subject { instance.table_exists?(table) }
@@ -74,7 +74,7 @@ describe Masamune::Helpers::Postgres do
     context 'with last_modified_at option' do
       before do
         expect(instance).to receive(:table_exists?).and_return(true)
-        expect(instance).to receive(:postgres).with(hash_including(exec: 'SELECT MAX(last_modified_at) FROM foo;', tuple_output: true, retries: 0)).and_yield(output).and_yield('')
+        expect(instance).to receive(:postgres).with(hash_including(exec: 'SELECT MAX(last_modified_at) FROM foo;', tuple_output: true, max_retries: 0)).and_yield(output).and_yield('')
       end
 
       let(:options) { { last_modified_at: 'last_modified_at' } }

--- a/spec/masamune/tasks/hive_thor_spec.rb
+++ b/spec/masamune/tasks/hive_thor_spec.rb
@@ -35,7 +35,7 @@ describe Masamune::Tasks::HiveThor do
     let(:options) { [] }
 
     it do
-      expect_any_instance_of(described_class).to receive(:hive).with(hash_including(retries: 0)).once.and_return(mock_success)
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_including(max_retries: 0)).once.and_return(mock_success)
       execute_command
     end
   end
@@ -85,7 +85,7 @@ describe Masamune::Tasks::HiveThor do
   context 'with --retry' do
     let(:options) { ['--retry'] }
     it do
-      expect_any_instance_of(described_class).to receive(:hive).with(hash_excluding(retries: 0)).once.and_return(mock_success)
+      expect_any_instance_of(described_class).to receive(:hive).with(hash_excluding(max_retries: 0)).once.and_return(mock_success)
       execute_command
     end
   end

--- a/spec/masamune/tasks/postgres_thor_spec.rb
+++ b/spec/masamune/tasks/postgres_thor_spec.rb
@@ -32,7 +32,7 @@ describe Masamune::Tasks::PostgresThor do
     let(:options) { [] }
 
     it do
-      expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(retries: 0)).once.and_return(mock_success)
+      expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(max_retries: 0)).once.and_return(mock_success)
       execute_command
     end
   end
@@ -40,7 +40,7 @@ describe Masamune::Tasks::PostgresThor do
   context 'with --file and --initialize' do
     let(:options) { ['--file=zombo.hql', '--initialize'] }
     it do
-      expect_any_instance_of(described_class).to receive(:postgres).with(file: instance_of(String), retries: 0).once.and_return(mock_success)
+      expect_any_instance_of(described_class).to receive(:postgres).with(file: instance_of(String), max_retries: 0).once.and_return(mock_success)
       expect_any_instance_of(described_class).to receive(:postgres).with(hash_including(file: 'zombo.hql')).once.and_return(mock_success)
       execute_command
     end
@@ -57,7 +57,7 @@ describe Masamune::Tasks::PostgresThor do
   context 'with --retry' do
     let(:options) { ['--retry'] }
     it do
-      expect_any_instance_of(described_class).to receive(:postgres).with(hash_excluding(retries: 0)).once.and_return(mock_success)
+      expect_any_instance_of(described_class).to receive(:postgres).with(hash_excluding(max_retries: 0)).once.and_return(mock_success)
       execute_command
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ ENV['MASAMUNE_ENV'] = 'test'
 Masamune::ExampleGroup.configure do |config|
   config.quiet    = ENV['MASAMUNE_DEBUG'] ? false : true
   config.debug    = ENV['MASAMUNE_DEBUG'] ? true : false
-  config.retries  = 0
+  config.max_retries  = 0
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ ENV['MASAMUNE_ENV'] = 'test'
 Masamune::ExampleGroup.configure do |config|
   config.quiet    = ENV['MASAMUNE_DEBUG'] ? false : true
   config.debug    = ENV['MASAMUNE_DEBUG'] ? true : false
-  config.max_retries  = 0
+  config.max_retries = 0
 end
 
 RSpec.configure do |config|

--- a/spec/support/masamune/shared_example_group.rb
+++ b/spec/support/masamune/shared_example_group.rb
@@ -78,7 +78,7 @@ module Masamune::SharedExampleGroup
     if configuration.commands.postgres[:clean]
       postgres_admin(action: :drop, database: configuration.commands.postgres[:database])
       postgres_admin(action: :create, database: configuration.commands.postgres[:database])
-      postgres(file: define_schema(catalog, :postgres).to_file, retries: 0)
+      postgres(file: define_schema(catalog, :postgres).to_file, max_retries: 0)
     end
     filesystem.paths.each do |_, (path, options)|
       filesystem.remove_dir(path) if options[:clean]


### PR DESCRIPTION
changes to ETL repo in this branch: https://github.com/socialcast/etl/tree/rename_retires_max_retries_SBI-1408
PR here : https://github.com/socialcast/etl/pull/399