### PR TITLE
Update rubocop

### DIFF
--- a/spec/support/masamune/shared_example_group.rb
+++ b/spec/support/masamune/shared_example_group.rb
@@ -119,7 +119,7 @@ module Masamune::SharedExampleGroup
     if output['hive'] && output['hive'].is_a?(String)
       hive(exec: output['hive'], output: output_file)
     elsif output['table']
-      table = eval "catalog.#{output['table']}" # rubocop:disable Lint/Eval
+      table = eval "catalog.#{output['table']}" # rubocop:disable Security/Eval
       query = denormalize_table(table, output.slice('columns', 'order', 'except', 'include')).to_s
       # FIXME: define format based on table.store.format
       case table.store.type


### PR DESCRIPTION
I noticed this RuboCop warning with latest version of RuboCop:
```
$ rubocop -v
0.47.1
$ rubocop
Inspecting 197 files
............................................................................................................................................................................................
masamune/spec/support/masamune/shared_example_group.rb: Lint/Eval has the wrong namespace - should be Security
.........
````