### PR TITLE
Remove VACUUM after INSERT/UPSERT

### DIFF
--- a/lib/masamune/transform/postgres/bulk_upsert.psql.erb
+++ b/lib/masamune/transform/postgres/bulk_upsert.psql.erb
@@ -64,6 +64,4 @@ WHERE
 
 COMMIT;
 
-VACUUM FULL ANALYZE <%= target.name %>;
-
 SELECT pg_advisory_unlock(<%= target.lock_id %>);

--- a/lib/masamune/transform/postgres/replace_table.psql.erb
+++ b/lib/masamune/transform/postgres/replace_table.psql.erb
@@ -50,8 +50,6 @@ ALTER TABLE <%= source.name %> RENAME TO <%= target.name %>;
 
 COMMIT;
 
-VACUUM FULL ANALYZE <%= target.name %>;
-
 DROP TABLE IF EXISTS <%= target_tmp.name %> CASCADE;
 DROP TABLE IF EXISTS <%= source.name %> CASCADE;
 

--- a/spec/masamune/transform/bulk_upsert.dimension_spec.rb
+++ b/spec/masamune/transform/bulk_upsert.dimension_spec.rb
@@ -128,8 +128,6 @@ describe Masamune::Transform::BulkUpsert do
 
         COMMIT;
 
-        VACUUM FULL ANALYZE user_dimension;
-
         SELECT pg_advisory_unlock(42);
       EOS
     end
@@ -196,8 +194,6 @@ describe Masamune::Transform::BulkUpsert do
         ;
 
         COMMIT;
-
-        VACUUM FULL ANALYZE user_dimension_ledger;
 
         SELECT pg_advisory_unlock(42);
       EOS

--- a/spec/masamune/transform/insert_reference_values.dimension_spec.rb
+++ b/spec/masamune/transform/insert_reference_values.dimension_spec.rb
@@ -99,8 +99,6 @@ describe Masamune::Transform::InsertReferenceValues do
 
         COMMIT;
 
-        VACUUM FULL ANALYZE department_type;
-
         SELECT pg_advisory_unlock(42);
       EOS
     end

--- a/spec/masamune/transform/insert_reference_values.fact_spec.rb
+++ b/spec/masamune/transform/insert_reference_values.fact_spec.rb
@@ -116,8 +116,6 @@ describe Masamune::Transform::InsertReferenceValues do
 
         COMMIT;
 
-        VACUUM FULL ANALYZE user_agent_type;
-
         SELECT pg_advisory_unlock(42);
 
         CREATE TEMPORARY TABLE IF NOT EXISTS feature_type_stage (LIKE feature_type INCLUDING ALL);
@@ -153,8 +151,6 @@ describe Masamune::Transform::InsertReferenceValues do
         ;
 
         COMMIT;
-
-        VACUUM FULL ANALYZE feature_type;
 
         SELECT pg_advisory_unlock(42);
       EOS

--- a/spec/masamune/transform/rollup_fact_spec.rb
+++ b/spec/masamune/transform/rollup_fact_spec.rb
@@ -167,8 +167,6 @@ describe Masamune::Transform::RollupFact do
 
         COMMIT;
 
-        VACUUM FULL ANALYZE visits_hourly_fact_y2014m08;
-
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage_tmp CASCADE;
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage CASCADE;
 
@@ -265,8 +263,6 @@ describe Masamune::Transform::RollupFact do
 
         COMMIT;
 
-        VACUUM FULL ANALYZE visits_daily_fact_y2014m08;
-
         DROP TABLE IF EXISTS visits_daily_fact_y2014m08_stage_tmp CASCADE;
         DROP TABLE IF EXISTS visits_daily_fact_y2014m08_stage CASCADE;
 
@@ -362,8 +358,6 @@ describe Masamune::Transform::RollupFact do
         CREATE INDEX visits_monthly_fact_y2014m08_39f0fdd_index ON visits_monthly_fact_y2014m08 (user_dimension_id);
 
         COMMIT;
-
-        VACUUM FULL ANALYZE visits_monthly_fact_y2014m08;
 
         DROP TABLE IF EXISTS visits_monthly_fact_y2014m08_stage_tmp CASCADE;
         DROP TABLE IF EXISTS visits_monthly_fact_y2014m08_stage CASCADE;

--- a/spec/masamune/transform/stage_fact_spec.rb
+++ b/spec/masamune/transform/stage_fact_spec.rb
@@ -237,8 +237,6 @@ describe Masamune::Transform::StageFact do
 
         COMMIT;
 
-        VACUUM FULL ANALYZE visits_hourly_fact_y2014m08;
-
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage_tmp CASCADE;
         DROP TABLE IF EXISTS visits_hourly_fact_y2014m08_stage CASCADE;
 


### PR DESCRIPTION
This is really the responsibility of the caller- either via auto-vacuum or by explicitly calling `VACUUM`. Additionally, vacuuming a shared table during parallel upsert has the potential to deadlock.